### PR TITLE
Include the Chef-cli as gem with the test-kitchen hab package

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -47,6 +47,7 @@ do_build() {
   bundle install
   ruby ./post-bundle-install.rb
   gem build chef-test-kitchen-enterprise.gemspec
+  gem install chef-cli
 }
 
 do_install() {
@@ -55,13 +56,27 @@ do_install() {
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
   gem install chef-test-kitchen-enterprise-*.gem --no-document
-  wrap_ruby_bin
+  gem install chef-cli
+  wrap_ruby_kitchen
+  wrap_ruby_chef_cli_bin
   set_runtime_env "GEM_PATH" "${pkg_prefix}/vendor/gems"
 }
 
-wrap_ruby_bin() {
+wrap_ruby_kitchen() {
   local bin="$pkg_prefix/bin/kitchen"
   local real_bin="$GEM_HOME/gems/chef-test-kitchen-enterprise-${pkg_version}/bin/kitchen"
+  wrap_bin_with_ruby "$bin" "$real_bin"
+}
+
+wrap_ruby_chef_cli_bin() {
+  local bin="$pkg_prefix/bin/chef-cli"
+  local real_bin="$GEM_HOME/bin/chef-cli"
+  wrap_bin_with_ruby "$bin" "$real_bin"
+}
+
+wrap_bin_with_ruby() {
+  local bin="$1"
+  local real_bin="$2"
   build_line "Adding wrapper $bin to $real_bin"
   cat <<EOF > "$bin"
 #!$(pkg_path_for core/bash)/bin/bash
@@ -71,9 +86,9 @@ set -e
 export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
 
 # Set Ruby paths defined from 'do_setup_environment()'
-  export GEM_HOME="$pkg_prefix/vendor/gems"
+export GEM_HOME="$pkg_prefix/vendor/gems"
+export GEM_PATH="\$GEM_HOME"
 
-  export GEM_PATH="$GEM_HOME"
 exec $(pkg_path_for $_chef_client_ruby)/bin/ruby $real_bin \$@
 EOF
   chmod -v 755 "$bin"

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -47,7 +47,6 @@ do_build() {
   bundle install
   ruby ./post-bundle-install.rb
   gem build chef-test-kitchen-enterprise.gemspec
-  gem install chef-cli
 }
 
 do_install() {
@@ -58,7 +57,7 @@ do_install() {
   gem install chef-test-kitchen-enterprise-*.gem --no-document
   gem install chef-cli
   wrap_ruby_kitchen
-  wrap_ruby_chef_cli_bin
+  wrap_ruby_chef_cli
   set_runtime_env "GEM_PATH" "${pkg_prefix}/vendor/gems"
 }
 
@@ -68,7 +67,7 @@ wrap_ruby_kitchen() {
   wrap_bin_with_ruby "$bin" "$real_bin"
 }
 
-wrap_ruby_chef_cli_bin() {
+wrap_ruby_chef_cli() {
   local bin="$pkg_prefix/bin/chef-cli"
   local real_bin="$GEM_HOME/bin/chef-cli"
   wrap_bin_with_ruby "$bin" "$real_bin"

--- a/lib/kitchen/provisioner/chef_infra.rb
+++ b/lib/kitchen/provisioner/chef_infra.rb
@@ -66,7 +66,7 @@ module Kitchen
         file_content = "nonce:#{nonce}\ntimestamp:#{timestamp}\nsignature:#{signature}"
         file_location = config[:root_path] + "/#{context_key}"
 
-        sudo("echo '#{file_content}' > #{file_location}")
+        "echo '#{file_content}' > #{file_location}"
       end
 
       def run_command


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The Chef-cli executable is needed for the test-kitchen to work correctly when the cookbook uses the policyfiles for dependency management. This PR adds the chef-cli as a gem to the test-kitchen hab package for the RC1 release.

Later, this will be reverted since the workstation hab package will have the chef-cli as a separate hab package. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
