### PR TITLE
Updated the kitchen context approach with env variable

### DIFF
--- a/lib/kitchen/licensing/config.rb
+++ b/lib/kitchen/licensing/config.rb
@@ -19,9 +19,8 @@
 require "chef-licensing"
 
 ChefLicensing.configure do |config|
-  config.chef_product_name = "Test Kitchen"
+  config.chef_product_name = "Chef Test Kitchen Enterprise"
   config.chef_entitlement_id = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
   config.chef_executable_name = "kitchen"
   config.license_server_url = "https://services.chef.io/licensing"
-  # config.license_server_url   = "https://licensing-acceptance.chef.co/License"
 end

--- a/lib/kitchen/provisioner/chef_infra.rb
+++ b/lib/kitchen/provisioner/chef_infra.rb
@@ -56,19 +56,6 @@ module Kitchen
         prepare_config_rb
       end
 
-      def prepare_command
-        nonce = Base64.encode64(SecureRandom.random_bytes(16)).strip
-        timestamp = Time.now.utc.to_i.to_s
-
-        message = "#{nonce}:#{timestamp}"
-        signature = OpenSSL::HMAC.hexdigest("SHA256", context_key, message)
-
-        file_content = "nonce:#{nonce}\ntimestamp:#{timestamp}\nsignature:#{signature}"
-        file_location = config[:root_path] + "/#{context_key}"
-
-        "echo '#{file_content}' > #{file_location}"
-      end
-
       def run_command
         cmd = "#{context_env_command} #{sudo(config[:chef_client_path])} --local-mode "
 
@@ -96,6 +83,14 @@ module Kitchen
         config[:chef_license_key] = key
         config[:install_sh_url] = install_sh_url
         config[:chef_license_type] = type
+      end
+
+      def chef_license_key
+        config[:chef_license_key]
+      end
+
+      def chef_license_server
+        config[:chef_license_server]
       end
 
       private
@@ -204,15 +199,11 @@ module Kitchen
         true
       end
 
-      def context_key
-        @context_key ||= SecureRandom.hex(16)
-      end
-
       def context_env_command
         if powershell_shell?
-          "$env:TEST_KITCHEN_CONTEXT = '#{context_key}'; &"
+          "$env:IS_KITCHEN = 'true'; &"
         else
-          "export TEST_KITCHEN_CONTEXT=#{context_key};"
+          "export IS_KITCHEN='true'; "
         end
       end
     end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
During the converge phase, the test-kitchen will set the IS_KITCHEN=true env variable on the target VM. The chef-client will check for this env variable and based on that it will use the chef-workstation's entitlement ID for that chef run.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
