### PR TITLE
use File.io instead of kernal.io or Io.read

### DIFF
--- a/lib/kitchen/loader/yaml.rb
+++ b/lib/kitchen/loader/yaml.rb
@@ -182,7 +182,7 @@ module Kitchen
       #   does not exist
       # @api private
       def read_file(file)
-        File.exist?(file.to_s) ? IO.read(file) : ""
+        File.exist?(file.to_s) ? File.read(file) : ""
       end
 
       # Determines the default absolute path to the Kitchen config YAML file,

--- a/lib/kitchen/metadata_chopper.rb
+++ b/lib/kitchen/metadata_chopper.rb
@@ -39,7 +39,7 @@ module Kitchen
     #
     # @param metadata_file [String] path to a metadata.rb file
     def initialize(metadata_file)
-      instance_eval(IO.read(metadata_file), metadata_file)
+      instance_eval(File.read(metadata_file), metadata_file)
     end
 
     def method_missing(meth, *args, &_block)

--- a/lib/kitchen/provisioner/chef/common_sandbox.rb
+++ b/lib/kitchen/provisioner/chef/common_sandbox.rb
@@ -295,7 +295,7 @@ module Kitchen
           Kitchen.mutex.synchronize do
             policy.compile
           end
-          policy_name = JSON.parse(IO.read(policy.lockfile))["name"]
+          policy_name = JSON.parse(File.read(policy.lockfile))["name"]
           policy_group = config[:policy_group] || "local"
           config[:attributes].merge(policy_name:, policy_group:)
         end

--- a/lib/kitchen/state_file.rb
+++ b/lib/kitchen/state_file.rb
@@ -85,7 +85,7 @@ module Kitchen
     # @return [String] a string representation of the yaml state file
     # @api private
     def read_file
-      IO.read(file_name)
+      File.read(file_name)
     end
 
     # Parses a YAML string and returns a Hash.

--- a/lib/kitchen/transport/winrm.rb
+++ b/lib/kitchen/transport/winrm.rb
@@ -253,7 +253,7 @@ module Kitchen
           if logger.debug?
             debug("Creating RDP document for #{instance_name} (#{rdp_doc_path})")
             debug("------------")
-            IO.read(rdp_doc_path).each_line { |l| debug(l.chomp.to_s) }
+            File.foreach(rdp_doc_path) { |line| debug(line.chomp) }
             debug("------------")
           end
         end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Use File.open instead of Kernel.open, as the former does not have this vulnerability. Similarly, use the methods from the Fileclass instead of the IO class e.g. File.read instead of IO.read.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
