### PR TITLE
[CHEF-18897] Add the berkshelf gem and use the chef-cli from the Chef-DKE

### DIFF
--- a/chef-test-kitchen-enterprise.gemspec
+++ b/chef-test-kitchen-enterprise.gemspec
@@ -38,4 +38,5 @@ Gem::Specification.new do |gem|
   # TK is not under Chef EULA
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3.0" # pinning until we can confirm 3+ works
   gem.add_dependency "chef-licensing",     "~> 1.0"
+  gem.add_dependency "berkshelf",          "~> 8.0" # for managing berks cookbooks
 end

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -12,8 +12,7 @@ $pkg_deps=@(
   "chef/ruby31-plus-devkit"
   "core/git"
 )
-$pkg_bin_dirs=@("bin"
-                "vendor/bin")
+$pkg_bin_dirs=@("bin")
 $project_root= (Resolve-Path "$PLAN_CONTEXT/../").Path
 
 function pkg_version {

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -12,7 +12,8 @@ $pkg_deps=@(
   "chef/ruby31-plus-devkit"
   "core/git"
 )
-$pkg_bin_dirs=@("bin")
+$pkg_bin_dirs=@("bin"
+                "vendor/bin")
 $project_root= (Resolve-Path "$PLAN_CONTEXT/../").Path
 
 function pkg_version {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -62,21 +62,13 @@ do_install() {
   build_line "Setting GEM_PATH=$GEM_HOME"
   export GEM_PATH="$GEM_HOME"
   gem install chef-test-kitchen-enterprise-*.gem --no-document
-  gem install chef-cli
   wrap_ruby_kitchen
-  wrap_ruby_chef_cli
   set_runtime_env "GEM_PATH" "${pkg_prefix}/vendor"
 }
 
 wrap_ruby_kitchen() {
   local bin="$pkg_prefix/bin/kitchen"
   local real_bin="$GEM_HOME/gems/chef-test-kitchen-enterprise-${pkg_version}/bin/kitchen"
-  wrap_bin_with_ruby "$bin" "$real_bin"
-}
-
-wrap_ruby_chef_cli() {
-  local bin="$pkg_prefix/bin/chef-cli"
-  local real_bin="$GEM_HOME/bin/chef-cli"
   wrap_bin_with_ruby "$bin" "$real_bin"
 }
 

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -156,7 +156,7 @@ module Kitchen
         # If the habitat package for chef-cli is installed and not binlinked,
         # return the hab pkg exec command to run chef-cli.
         def hab_chef_cli
-          "hab pkg exec chef/chef-cli chef-cli" if hab_pkg_installed?("chef-cli")
+          "hab pkg exec chef/chef-cli chef-cli" if hab_pkg_installed?("chef/chef-cli")
         end
 
         # Check whether a habitat package is installed or not

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -170,9 +170,9 @@ module Kitchen
 
         # @api private
         def no_cli_found_error
-          @logger.fatal("The `chef-cli` executable or `chef/chef-cli` habitat package cannot be found in your " \
-                        "PATH. Ensure you have installed Chef Development Kit Enterprise habitat package.")
-          raise UserError, "Could not find the chef-cli executables in your PATH."
+          @logger.fatal("The `chef-cli` executable or the `chef/chef-cli` Habitat package cannot be found in your PATH. " \
+                        "Ensure that you have installed the Chef Development Kit Enterprise Habitat package.")
+          raise UserError, "Could not find the chef-cli executables or the chef/chef-cli hab package."
         end
       end
     end

--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -150,16 +150,29 @@ module Kitchen
         # @api private
         # @returns [String]
         def cli_path
-          @cli_path ||= which("chef-cli") || which("chef") || no_cli_found_error
+          @cli_path ||= which("chef-cli") || hab_chef_cli || no_cli_found_error
+        end
+
+        # If the habitat package for chef-cli is installed and not binlinked,
+        # return the hab pkg exec command to run chef-cli.
+        def hab_chef_cli
+          "hab pkg exec chef/chef-cli chef-cli" if hab_pkg_installed?("chef-cli")
+        end
+
+        # Check whether a habitat package is installed or not
+        def hab_pkg_installed?(pkg)
+          if which("hab")
+            `hab pkg list #{pkg} 2>/dev/null`.include?(pkg)
+          else
+            false
+          end
         end
 
         # @api private
         def no_cli_found_error
-          @logger.fatal("The `chef` or `chef-cli` executables cannot be found in your " \
-                        "PATH. Ensure you have installed Chef Workstation " \
-                        "from https://www.chef.io/downloads/ and that your PATH " \
-                        "setting includes the path to the `chef` or `chef-cli` commands.")
-          raise UserError, "Could not find the chef or chef-cli executables in your PATH."
+          @logger.fatal("The `chef-cli` executable or `chef/chef-cli` habitat package cannot be found in your " \
+                        "PATH. Ensure you have installed Chef Development Kit Enterprise habitat package.")
+          raise UserError, "Could not find the chef-cli executables in your PATH."
         end
       end
     end

--- a/spec/kitchen/provisioner/chef/policyfile_spec.rb
+++ b/spec/kitchen/provisioner/chef/policyfile_spec.rb
@@ -48,10 +48,10 @@ describe Kitchen::Provisioner::Chef::Policyfile do
   describe "#resolve" do
     subject { described_object.resolve }
 
-    describe "on Unix with chef" do
+    describe "on Unix with chef-cli hab pkg" do
       before do
         described_object.expects(:which).with("chef-cli").returns(false)
-        described_object.expects(:which).with("chef").returns("chef")
+        described_object.expects(:hab_pkg_installed?).with("chef/chef-cli").returns(true)
       end
 
       let(:os) { "linux-gnu" }
@@ -61,7 +61,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:path) { "/tmp/kitchen/cookbooks" }
         let(:license) { "accept" }
         it do
-          described_object.expects(:run_command).with("chef export /home/user/cookbook/Policyfile.rb /tmp/kitchen/cookbooks --force --chef-license accept")
+          described_object.expects(:run_command).with("hab pkg exec chef/chef-cli chef-cli export /home/user/cookbook/Policyfile.rb /tmp/kitchen/cookbooks --force --chef-license accept")
           subject
         end
       end
@@ -71,7 +71,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:path) { "/tmp/kitchen/cookbooks" }
         let(:license) { "accept-silent" }
         it do
-          described_object.expects(:run_command).with("chef export /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb /tmp/kitchen/cookbooks --force --chef-license accept-silent")
+          described_object.expects(:run_command).with("hab pkg exec chef/chef-cli chef-cli export /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb /tmp/kitchen/cookbooks --force --chef-license accept-silent")
           subject
         end
       end
@@ -81,7 +81,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:path) { "/tmp/kitchen/cookbooks" }
         let(:license) { "accept-no-persist" }
         it do
-          described_object.expects(:run_command).with("chef export /home/user/cookbook/Policyfile.rb /tmp/kitchen/cookbooks --force --chef-license accept-no-persist")
+          described_object.expects(:run_command).with("hab pkg exec chef/chef-cli chef-cli export /home/user/cookbook/Policyfile.rb /tmp/kitchen/cookbooks --force --chef-license accept-no-persist")
           subject
         end
       end
@@ -125,10 +125,10 @@ describe Kitchen::Provisioner::Chef::Policyfile do
       end
     end
 
-    describe "on Windows with chef" do
+    describe "on Windows with chef-cli hab pkg" do
       before do
         described_object.expects(:which).with("chef-cli").returns(false)
-        described_object.expects(:which).with("chef").returns("chef")
+        described_object.expects(:hab_pkg_installed?).with("chef/chef-cli").returns(true)
       end
 
       let(:os) { "mswin" }
@@ -138,7 +138,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:path) { 'C:\\Temp\\kitchen\\cookbooks' }
         let(:license) { "accept" }
         it do
-          described_object.expects(:run_command).with('chef export C:\\cookbook\\Policyfile.rb C:\\Temp\\kitchen\\cookbooks --force --chef-license accept')
+          described_object.expects(:run_command).with('hab pkg exec chef/chef-cli chef-cli export C:\\cookbook\\Policyfile.rb C:\\Temp\\kitchen\\cookbooks --force --chef-license accept')
           subject
         end
       end
@@ -148,7 +148,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:path) { 'C:\\Temp\\kitchen\\cookbooks' }
         let(:license) { "accept-silent" }
         it do
-          described_object.expects(:run_command).with('chef export "C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb" C:\\Temp\\kitchen\\cookbooks --force --chef-license accept-silent')
+          described_object.expects(:run_command).with('hab pkg exec chef/chef-cli chef-cli export "C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb" C:\\Temp\\kitchen\\cookbooks --force --chef-license accept-silent')
           subject
         end
       end
@@ -158,7 +158,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:path) { 'C:\\Temp\\kitchen\\cookbooks' }
         let(:license) { "accept-no-persist" }
         it do
-          described_object.expects(:run_command).with('chef export "C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb" C:\\Temp\\kitchen\\cookbooks --force --chef-license accept-no-persist')
+          described_object.expects(:run_command).with('hab pkg exec chef/chef-cli chef-cli export "C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb" C:\\Temp\\kitchen\\cookbooks --force --chef-license accept-no-persist')
           subject
         end
       end
@@ -205,7 +205,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
     describe "failure to resolve paths" do
       before do
         described_object.expects(:which).with("chef-cli").returns(false)
-        described_object.expects(:which).with("chef").returns(false)
+        described_object.expects(:hab_pkg_installed?).with("chef/chef-cli").returns(false)
       end
 
       let(:os) { "linux-gnu" }
@@ -292,10 +292,10 @@ describe Kitchen::Provisioner::Chef::Policyfile do
       end
     end
 
-    describe "on Unix with chef" do
+    describe "on Unix with chef-cli hab pkg" do
       before do
         described_object.expects(:which).with("chef-cli").returns(false)
-        described_object.expects(:which).with("chef").returns("chef")
+        described_object.expects(:hab_pkg_installed?).with("chef/chef-cli").returns(true)
       end
 
       let(:os) { "linux-gnu" }
@@ -304,7 +304,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:policyfile) { "/home/user/cookbook/Policyfile.rb" }
         let(:license) { "accept" }
         it do
-          described_object.expects(:run_command).with("chef install /home/user/cookbook/Policyfile.rb --chef-license accept")
+          described_object.expects(:run_command).with("hab pkg exec chef/chef-cli chef-cli install /home/user/cookbook/Policyfile.rb --chef-license accept")
           subject
         end
       end
@@ -313,7 +313,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:policyfile) { "/home/jenkins/My Chef Cookbook/workspace/current/Policyfile.rb" }
         let(:license) { "accept-silent" }
         it do
-          described_object.expects(:run_command).with('chef install /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb --chef-license accept-silent')
+          described_object.expects(:run_command).with('hab pkg exec chef/chef-cli chef-cli install /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb --chef-license accept-silent')
           subject
         end
       end
@@ -322,16 +322,16 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:policyfile) { "/home/jenkins/My Chef Cookbook/workspace/current/Policyfile.rb" }
         let(:license) { "accept-no-persist" }
         it do
-          described_object.expects(:run_command).with('chef install /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb --chef-license accept-no-persist')
+          described_object.expects(:run_command).with('hab pkg exec chef/chef-cli chef-cli install /home/jenkins/My\\ Chef\\ Cookbook/workspace/current/Policyfile.rb --chef-license accept-no-persist')
           subject
         end
       end
     end
 
-    describe "on Windows with chef" do
+    describe "on Windows with chef-cli hab pkg" do
       before do
         described_object.expects(:which).with("chef-cli").returns(false)
-        described_object.expects(:which).with("chef").returns("chef")
+        described_object.expects(:hab_pkg_installed?).with("chef/chef-cli").returns(true)
       end
 
       let(:os) { "mswin" }
@@ -340,7 +340,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:policyfile) { 'C:\\cookbook\\Policyfile.rb' }
         let(:license) { "accept" }
         it do
-          described_object.expects(:run_command).with('chef install C:\\cookbook\\Policyfile.rb --chef-license accept')
+          described_object.expects(:run_command).with('hab pkg exec chef/chef-cli chef-cli install C:\\cookbook\\Policyfile.rb --chef-license accept')
           subject
         end
       end
@@ -349,7 +349,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:policyfile) { 'C:\\Program Files\\Jenkins\\My Chef Cookbook\\workspace\\current\\Policyfile.rb' }
         let(:license) { "accept-silent" }
         it do
-          described_object.expects(:run_command).with('chef install "C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb" --chef-license accept-silent')
+          described_object.expects(:run_command).with('hab pkg exec chef/chef-cli chef-cli install "C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb" --chef-license accept-silent')
           subject
         end
       end
@@ -358,7 +358,7 @@ describe Kitchen::Provisioner::Chef::Policyfile do
         let(:policyfile) { 'C:\\Program Files\\Jenkins\\My Chef Cookbook\\workspace\\current\\Policyfile.rb' }
         let(:license) { "accept-no-persist" }
         it do
-          described_object.expects(:run_command).with('chef install "C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb" --chef-license accept-no-persist')
+          described_object.expects(:run_command).with('hab pkg exec chef/chef-cli chef-cli install "C:\\\\Program\\ Files\\\\Jenkins\\\\My\\ Chef\\ Cookbook\\\\workspace\\\\current\\\\Policyfile.rb" --chef-license accept-no-persist')
           subject
         end
       end


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
In chef-test-kitchen-enterprise, we have a dependency on the berkshelf and chef-cli. The berkshlf is a gem dependency so I added that in the gemspec file. The chef-cli is a binary dependency, so it expects the chef/chef-cli or chef/chef-development-kit-enterprise hab package to be installed already or it will show an error to install the same. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
