### PR TITLE
[Do not merge] Fix dependency conflict with hashie for chef-zero-15.0.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 gem "appbundler"
 gem "pry"
 gem "kitchen-dokken", git: "https://github.com/chef/kitchen-dokken", branch: "main"
-gem "kitchen-inspec", git: "https://github.com/inspec/kitchen-inspec", branch: "temp-point-to-chef-test-kitchen-ent"
+gem "kitchen-inspec", git: "https://github.com/sanjain-progress/kitchen-inspec", branch: "sanjain/fix/update_dependency"
 
 group :test do
   gem "rake"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Resolving a dependency conflict in kitchen inspec (https://github.com/sanjain-progress/kitchen-inspec/commit/bf96416a30c359efcb863c6e7aa8def5c3874a60) in hashie  gem to ensure compatibility with chef-zero-15.0.11.
## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
