### PR TITLE
[CHEF-21374] Removed the licensing changes

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -19,7 +19,7 @@ steps:
           image: ruby:3.1
           environment:
             - CHEF_LICENSE=accept-no-persist
-            - CHEF_LICENSE_SERVER=http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/
+#            - CHEF_LICENSE_SERVER=http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/
 
   - label: run-specs-ruby-3.3
     command:
@@ -30,7 +30,7 @@ steps:
           image: ruby:3.3
           environment:
             - CHEF_LICENSE=accept-no-persist
-            - CHEF_LICENSE_SERVER=http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/
+#            - CHEF_LICENSE_SERVER=http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/
 
   - label: run-specs-windows-ruby-3.1
     command:
@@ -46,7 +46,7 @@ steps:
             - FORCE_FFI_YAJL=ext
             - EXPIRE_CACHE=true
             - CHEF_LICENSE=accept-no-persist
-            - CHEF_LICENSE_SERVER=http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/
+#            - CHEF_LICENSE_SERVER=http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/
 
   - label: run-specs-windows-ruby-3.3
     command:
@@ -62,4 +62,4 @@ steps:
             - FORCE_FFI_YAJL=ext
             - EXPIRE_CACHE=true
             - CHEF_LICENSE=accept-no-persist
-            - CHEF_LICENSE_SERVER=http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/
+#            - CHEF_LICENSE_SERVER=http://hosted-license-service-lb-8000-606952349.us-west-2.elb.amazonaws.com:8000/

--- a/chef-test-kitchen-enterprise.gemspec
+++ b/chef-test-kitchen-enterprise.gemspec
@@ -37,6 +37,6 @@ Gem::Specification.new do |gem|
   # Required to run the Chef provisioner local license check for remote systems
   # TK is not under Chef EULA
   gem.add_dependency "license-acceptance", ">= 1.0.11", "< 3.0" # pinning until we can confirm 3+ works
-  gem.add_dependency "chef-licensing",     "~> 1.0"
+  # gem.add_dependency "chef-licensing",     "~> 1.0"
   gem.add_dependency "berkshelf",          "~> 8.0" # for managing berks cookbooks
 end

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -301,10 +301,10 @@ module Kitchen
       perform("console", "console")
     end
 
-    desc "license", "Manage the chef licenses"
-    def license(*args)
-      perform("license", "license", args)
-    end
+    # desc "license", "Manage the chef licenses"
+    # def license(*args)
+    #   perform("license", "license", args)
+    # end
 
     register Kitchen::Generator::Init, "init",
       "init", "Adds some configuration to your cookbook so Kitchen can rock"

--- a/lib/kitchen/command/license.rb
+++ b/lib/kitchen/command/license.rb
@@ -1,80 +1,80 @@
-# frozen_string_literal: true
-
-require_relative "../command"
-require "kitchen/licensing/base"
-
-module Kitchen
-  module Command
-    # Command to manage the licenses
-    class License < Kitchen::Command::Base
-      BANNER = <<~MSG
-
-      Usage:
-        kitchen license            # Add new license or list the activated license(s)
-        kitchen license add        # Add a new license
-        kitchen license list       # List details of the activated license(s)
-
-      Options:
-        [-h/--help]                # Shows the help message
-        [--chef-license-key=<KEY>] # License key can be passed as this optional argument as well
-                                   # eg: kitchen license --chef-license-key=KEY123
-      MSG
-
-      SUB_COMMANDS = %w{add list}.freeze
-      OPTIONS      = %w{--chef-license-key -h --help}.freeze
-
-      def call
-        result = validate_arguments!
-
-        case result
-        when "list"
-          ChefLicensing.list_license_keys_info
-        when "add"
-          ChefLicensing.add_license
-        when "help"
-          print_help
-        else
-          ChefLicensing.fetch_and_persist.each do |key|
-            puts "License_key: #{key}"
-          end
-        end
-      rescue ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError
-        logger.debug("License key not fetched. Please try again.")
-      end
-
-      private
-
-      def print_help(error = nil)
-        puts error if error
-        puts BANNER
-        exit(1) if error
-      end
-
-      def validate_arguments!
-        return if args.empty?
-
-        if args.any? { |arg| arg == "-h" || arg == "--help" }
-          return "help"
-        end
-
-        validate_subcommands(args)
-        args[0]
-      end
-
-      def validate_subcommands(array, last_element = nil)
-        return unless array.any?
-
-        # If the last element is --chef-license-key, then the next element should be the license key
-        # So no need to validate it
-        if last_element == "--chef-license-key"
-          validate_subcommands(array[1..-1], array[0])
-        else
-          unless (SUB_COMMANDS + OPTIONS).include?(array[0].split("=").first)
-            print_help("Invalid Option: #{array[0]}")
-          end
-          validate_subcommands(array[1..-1], array[0])
-        end
-      end
-    end
-  end
-end
+# # frozen_string_literal: true
+#
+# require_relative "../command"
+# require "kitchen/licensing/base"
+#
+# module Kitchen
+#   module Command
+#     # Command to manage the licenses
+#     class License < Kitchen::Command::Base
+#       BANNER = <<~MSG
+#
+#       Usage:
+#         kitchen license            # Add new license or list the activated license(s)
+#         kitchen license add        # Add a new license
+#         kitchen license list       # List details of the activated license(s)
+#
+#       Options:
+#         [-h/--help]                # Shows the help message
+#         [--chef-license-key=<KEY>] # License key can be passed as this optional argument as well
+#                                    # eg: kitchen license --chef-license-key=KEY123
+#       MSG
+#
+#       SUB_COMMANDS = %w{add list}.freeze
+#       OPTIONS      = %w{--chef-license-key -h --help}.freeze
+#
+#       def call
+#         result = validate_arguments!
+#
+#         case result
+#         when "list"
+#           ChefLicensing.list_license_keys_info
+#         when "add"
+#           ChefLicensing.add_license
+#         when "help"
+#           print_help
+#         else
+#           ChefLicensing.fetch_and_persist.each do |key|
+#             puts "License_key: #{key}"
+#           end
+#         end
+#       rescue ChefLicensing::LicenseKeyFetcher::LicenseKeyNotFetchedError
+#         logger.debug("License key not fetched. Please try again.")
+#       end
+#
+#       private
+#
+#       def print_help(error = nil)
+#         puts error if error
+#         puts BANNER
+#         exit(1) if error
+#       end
+#
+#       def validate_arguments!
+#         return if args.empty?
+#
+#         if args.any? { |arg| arg == "-h" || arg == "--help" }
+#           return "help"
+#         end
+#
+#         validate_subcommands(args)
+#         args[0]
+#       end
+#
+#       def validate_subcommands(array, last_element = nil)
+#         return unless array.any?
+#
+#         # If the last element is --chef-license-key, then the next element should be the license key
+#         # So no need to validate it
+#         if last_element == "--chef-license-key"
+#           validate_subcommands(array[1..-1], array[0])
+#         else
+#           unless (SUB_COMMANDS + OPTIONS).include?(array[0].split("=").first)
+#             print_help("Invalid Option: #{array[0]}")
+#           end
+#           validate_subcommands(array[1..-1], array[0])
+#         end
+#       end
+#     end
+#   end
+# end

--- a/lib/kitchen/licensing/base.rb
+++ b/lib/kitchen/licensing/base.rb
@@ -16,38 +16,38 @@
 # limitations under the License.
 #
 
-require_relative "config"
-require "chef-licensing"
-require "faraday_middleware"
-
-module Kitchen
-  module Licensing
-    class Base
-
-      OMNITRUCK_URLS = {
-        "free"       => "https://chefdownload-trial.chef.io",
-        "trial"      => "https://chefdownload-trial.chef.io",
-        "commercial" => "https://chefdownload-commerical.chef.io",
-      }.freeze
-
-      class << self
-        def get_license_keys
-          keys = ChefLicensing.license_keys
-          raise ChefLicensing::InvalidLicense, "A valid license is required to perform this action. Run <kitchen license> command to generate/activate the license." if keys.blank?
-
-          client = get_license_client(keys)
-
-          [keys.last, client.license_type, install_sh_url(client.license_type, keys)]
-        end
-
-        def get_license_client(keys)
-          ChefLicensing::Api::Client.info(license_keys: keys)
-        end
-
-        def install_sh_url(type, keys, ext = "sh")
-          OMNITRUCK_URLS[type] + "/install.#{ext}?license_id=#{keys.join(",")}"
-        end
-      end
-    end
-  end
-end
+# require_relative "config"
+# require "chef-licensing"
+# require "faraday_middleware"
+#
+# module Kitchen
+#   module Licensing
+#     class Base
+#
+#       OMNITRUCK_URLS = {
+#         "free"       => "https://chefdownload-trial.chef.io",
+#         "trial"      => "https://chefdownload-trial.chef.io",
+#         "commercial" => "https://chefdownload-commerical.chef.io",
+#       }.freeze
+#
+#       class << self
+#         def get_license_keys
+#           keys = ChefLicensing.license_keys
+#           raise ChefLicensing::InvalidLicense, "A valid license is required to perform this action. Run <kitchen license> command to generate/activate the license." if keys.blank?
+#
+#           client = get_license_client(keys)
+#
+#           [keys.last, client.license_type, install_sh_url(client.license_type, keys)]
+#         end
+#
+#         def get_license_client(keys)
+#           ChefLicensing::Api::Client.info(license_keys: keys)
+#         end
+#
+#         def install_sh_url(type, keys, ext = "sh")
+#           OMNITRUCK_URLS[type] + "/install.#{ext}?license_id=#{keys.join(",")}"
+#         end
+#       end
+#     end
+#   end
+# end

--- a/lib/kitchen/licensing/config.rb
+++ b/lib/kitchen/licensing/config.rb
@@ -16,27 +16,27 @@
 # limitations under the License.
 #
 
-require "chef-licensing"
-
-module Kitchen
-  module Licensing
-    PRODUCT_NAME = "Test Kitchen Enterprise"
-    ENTITLEMENT_ID = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
-    EXECUTABLE_NAME = "kitchen"
-    GLOBAL_LICENSE_SERVER = "https://services.chef.io/licensing"
-
-    class << self
-      def configure_licensing
-        ChefLicensing.configure do |config|
-          config.chef_product_name = PRODUCT_NAME
-          config.chef_entitlement_id = ENTITLEMENT_ID
-          config.chef_executable_name = EXECUTABLE_NAME
-          config.license_server_url = GLOBAL_LICENSE_SERVER
-        end
-      end
-    end
-  end
-end
-
-# This needs to be called initially to configure the licensing
-Kitchen::Licensing.configure_licensing
+# require "chef-licensing"
+#
+# module Kitchen
+#   module Licensing
+#     PRODUCT_NAME = "Test Kitchen Enterprise"
+#     ENTITLEMENT_ID = "x6f3bc76-a94f-4b6c-bc97-4b7ed2b045c0"
+#     EXECUTABLE_NAME = "kitchen"
+#     GLOBAL_LICENSE_SERVER = "https://services.chef.io/licensing"
+#
+#     class << self
+#       def configure_licensing
+#         ChefLicensing.configure do |config|
+#           config.chef_product_name = PRODUCT_NAME
+#           config.chef_entitlement_id = ENTITLEMENT_ID
+#           config.chef_executable_name = EXECUTABLE_NAME
+#           config.license_server_url = GLOBAL_LICENSE_SERVER
+#         end
+#       end
+#     end
+#   end
+# end
+#
+# # This needs to be called initially to configure the licensing
+# Kitchen::Licensing.configure_licensing

--- a/lib/kitchen/plugin.rb
+++ b/lib/kitchen/plugin.rb
@@ -54,12 +54,12 @@ module Kitchen
                         " in your Gemfile if using Bundler."
                       end
       raise ClientError, "Could not load the '#{plugin}' #{type_name} from the load path." + error_message
-    ensure
+    # ensure
       # If any of the plugins has a different licensing configuration, after loading it,
       # it might override the kitchen licensing configuration. To fix this issue we will reconfigure it again.
-      if ChefLicensing::Config.chef_entitlement_id != Kitchen::Licensing::ENTITLEMENT_ID
-        Kitchen::Licensing.configure_licensing
-      end
+      # if ChefLicensing::Config.chef_entitlement_id != Kitchen::Licensing::ENTITLEMENT_ID
+      #   Kitchen::Licensing.configure_licensing
+      # end
     end
 
     # given a type of plugin, searches the Ruby load path for plugins of that

--- a/lib/kitchen/provisioner/chef_infra.rb
+++ b/lib/kitchen/provisioner/chef_infra.rb
@@ -36,7 +36,7 @@ module Kitchen
       default_config :chef_zero_host, nil
       default_config :chef_zero_port, 8889
       default_config :chef_license_key, nil
-      default_config :chef_license_server, []
+      # default_config :chef_license_server, []
 
       default_config :chef_client_path do |provisioner|
         provisioner
@@ -62,36 +62,36 @@ module Kitchen
         chef_cmd(cmd)
       end
 
-      def check_license
-        super
-
-        info("Fetching the Chef license key")
-        unless config[:chef_license_server].nil? || config[:chef_license_server].empty?
-          ENV["CHEF_LICENSE_SERVER"] = config[:chef_license_server].join(",")
-        end
-
-        key, type, install_sh_url = if config[:chef_license_key].nil?
-                                      Licensing::Base.get_license_keys
-                                    else
-                                      key = config[:chef_license_key]
-                                      client = Licensing::Base.get_license_client([key])
-
-                                      [key, client.license_type, Licensing::Base.install_sh_url(client.license_type, [key])]
-                                    end
-
-        info("Chef license key: #{key}")
-        config[:chef_license_key] = key
-        config[:install_sh_url] = install_sh_url
-        config[:chef_license_type] = type
-      end
-
-      def chef_license_key
-        config[:chef_license_key]
-      end
-
-      def chef_license_server
-        config[:chef_license_server]
-      end
+      # def check_license
+      #   super
+      #
+      #   info("Fetching the Chef license key")
+      #   unless config[:chef_license_server].nil? || config[:chef_license_server].empty?
+      #     ENV["CHEF_LICENSE_SERVER"] = config[:chef_license_server].join(",")
+      #   end
+      #
+      #   key, type, install_sh_url = if config[:chef_license_key].nil?
+      #                                 Licensing::Base.get_license_keys
+      #                               else
+      #                                 key = config[:chef_license_key]
+      #                                 client = Licensing::Base.get_license_client([key])
+      #
+      #                                 [key, client.license_type, Licensing::Base.install_sh_url(client.license_type, [key])]
+      #                               end
+      #
+      #   info("Chef license key: #{key}")
+      #   config[:chef_license_key] = key
+      #   config[:install_sh_url] = install_sh_url
+      #   config[:chef_license_type] = type
+      # end
+      #
+      # def chef_license_key
+      #   config[:chef_license_key]
+      # end
+      #
+      # def chef_license_server
+      #   config[:chef_license_server]
+      # end
 
       private
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR will remove the licensing changes introduced for the chef-infra-client 19 which includes the following.

- Removed the kitchen license commands
- Enforcing the license for the kitchen converge and kitchen verify commands.
- Passing the license key to the created node to activate it there.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
