### PR TITLE
GHCP — Crawl: Ex2 deterministic test

### DIFF
--- a/spec/kitchen/verifier/dummy_spec.rb
+++ b/spec/kitchen/verifier/dummy_spec.rb
@@ -86,6 +86,13 @@ describe Kitchen::Verifier::Dummy do
       _ { verifier.call(state) }.must_raise Kitchen::ActionFailed
     end
 
+    it "does not raise when :random_failure is set and random check is false" do
+      config[:random_failure] = true
+      verifier.stubs(:randomly_fail?).returns(false)
+
+      verifier.call(state)
+    end
+
     it "logs a converge event to INFO" do
       verifier.call(state)
 


### PR DESCRIPTION
Summary: Added one deterministic unit test for verifier dummy behavior in random-failure mode.\nEvidence: bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb (9 runs, 9 assertions, 0 failures, 0 errors, 0 skips).\nRisk: Low\nRollback: revert commit 75f5897e6dbe8b665edbbf9a7d0966c0cb6c8a15