### PR TITLE
GHCP — Crawl: Ex3 tiny refactor

### DIFF
--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -56,11 +56,15 @@ module Kitchen
       def failure_if_set
         if config[:fail]
           debug("Failure for Verifier #{name}.")
-          raise ActionFailed, "Action #verify failed for #{instance.to_str}."
+          fail_verify!
         elsif config[:random_failure] && randomly_fail?
           debug("Random failure for Verifier #{name}.")
-          raise ActionFailed, "Action #verify failed for #{instance.to_str}."
+          fail_verify!
         end
+      end
+
+      def fail_verify!
+        raise ActionFailed, "Action #verify failed for #{instance.to_str}."
       end
 
       # Determine whether or not to randomly fail.

--- a/spec/kitchen/verifier/dummy_spec.rb
+++ b/spec/kitchen/verifier/dummy_spec.rb
@@ -79,6 +79,13 @@ describe Kitchen::Verifier::Dummy do
       _ { verifier.call(state) }.must_raise Kitchen::ActionFailed
     end
 
+    it "raises ActionFailed with a stable message if :fail is set" do
+      config[:fail] = true
+
+      error = _ { verifier.call(state) }.must_raise Kitchen::ActionFailed
+      _(error.message).must_equal "Action #verify failed for instance."
+    end
+
     it "randomly raises ActionFailed if :random_failure is set" do
       config[:random_failure] = true
       verifier.stubs(:randomly_fail?).returns(true)


### PR DESCRIPTION
Summary: Tiny readability refactor in dummy verifier preserving behavior, plus deterministic unit-test coverage adjustment.
Evidence: bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb (10 runs, 11 assertions, 0 failures, 0 errors, 0 skips)
Risk: Low
Rollback: revert commit 45e91394