### PR TITLE
GHCP — Crawl: Ex4 documentation sync

### DIFF
--- a/ai-track-docs/verifier-dummy-extending.md
+++ b/ai-track-docs/verifier-dummy-extending.md
@@ -1,0 +1,49 @@
+# Extending Kitchen::Verifier::Dummy
+
+This guide covers small, low-risk ways to extend the dummy verifier in:
+- `lib/kitchen/verifier/dummy.rb`
+
+## Module Role
+`Kitchen::Verifier::Dummy` is a simulation verifier. It is useful for testing lifecycle flow and plugin behavior without external verifier dependencies.
+
+Current behavior:
+- logs verify start/end
+- supports optional sleep (`:sleep`)
+- supports deterministic fail (`:fail`)
+- supports probabilistic fail (`:random_failure`)
+
+## Safe Extension Points
+1. Add config flags with `default_config` for optional behavior.
+2. Add log detail in `call(state)` without changing control flow.
+3. Add helper methods called from `failure_if_set` for clearer branching.
+4. Keep `ActionFailed` messages stable when changing failure helpers.
+
+## Example: Add A New Optional Toggle
+If you add `default_config :verbose_verify, false`:
+1. Read it in `call(state)`.
+2. Emit extra `debug` output only when true.
+3. Do not change return type or exception behavior.
+
+## Minimal Test Strategy
+Use focused unit specs in:
+- `spec/kitchen/verifier/dummy_spec.rb`
+
+Recommended checks for each extension:
+1. Default config value is set correctly.
+2. Positive path works with no exception.
+3. Failure path still raises `Kitchen::ActionFailed` when expected.
+4. Message text is stable for failure assertions.
+5. Logging assertions cover any new debug/info output.
+
+## Validate Changes
+Run the focused verifier spec:
+
+```bash
+bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb
+```
+
+Optionally run all unit tests:
+
+```bash
+bundle exec rake unit
+```

--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -51,6 +51,7 @@ module Kitchen
       end
 
       # Simulate a failure in an action, if set in the config.
+      # Priority is explicit failure (`:fail`) over random failure.
       #
       # @api private
       def failure_if_set
@@ -63,6 +64,10 @@ module Kitchen
         end
       end
 
+      # Raise a verify-specific ActionFailed with a stable message.
+      #
+      # @raise [ActionFailed]
+      # @api private
       def fail_verify!
         raise ActionFailed, "Action #verify failed for #{instance.to_str}."
       end


### PR DESCRIPTION
Summary: Added concise doc comments in the dummy verifier and a short module extension guide.
Evidence: bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb (10 runs, 11 assertions, 0 failures, 0 errors, 0 skips)
Risk: Low
Rollback: revert commit 7b0d3087