### PR TITLE
GHCP — Crawl: Ex5 minimal validation and negative test

### DIFF
--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -35,6 +35,7 @@ module Kitchen
 
       # (see Base#call)
       def call(state)
+        validate_state!(state)
         info("[#{name}] Verify on instance=#{instance} with state=#{state}")
         sleep_if_set
         failure_if_set
@@ -62,6 +63,17 @@ module Kitchen
           debug("Random failure for Verifier #{name}.")
           fail_verify!
         end
+      end
+
+      # Ensure the public call boundary receives the expected state type.
+      #
+      # @param state [Hash]
+      # @raise [ArgumentError]
+      # @api private
+      def validate_state!(state)
+        return if state.is_a?(Hash)
+
+        raise ArgumentError, "state must be a Hash"
       end
 
       # Raise a verify-specific ActionFailed with a stable message.

--- a/spec/kitchen/verifier/dummy_spec.rb
+++ b/spec/kitchen/verifier/dummy_spec.rb
@@ -66,6 +66,11 @@ describe Kitchen::Verifier::Dummy do
   end
 
   describe "#call" do
+    it "raises ArgumentError when state is not a Hash" do
+      error = _ { verifier.call("not-a-hash") }.must_raise ArgumentError
+      _(error.message).must_equal "state must be a Hash"
+    end
+
     it "calls sleep if :sleep value is greater than 0" do
       config[:sleep] = 12.5
       verifier.expects(:sleep).with(12.5).returns(true)


### PR DESCRIPTION
Summary: Added minimal state input validation at the dummy verifier call boundary and a negative unit test.
Evidence: bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb (11 runs, 13 assertions, 0 failures, 0 errors, 0 skips)
Risk: Low
Rollback: revert commit 9ac4e39a