### PR TITLE
GHCP — Crawl: Ex6 performance baseline

### DIFF
--- a/ai-track-docs/benchmarks/verifier-dummy-call-benchmark.rb
+++ b/ai-track-docs/benchmarks/verifier-dummy-call-benchmark.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "benchmark"
+require "logger"
+require "ostruct"
+require "stringio"
+
+$LOAD_PATH.unshift(File.expand_path("../../lib", __dir__))
+require "kitchen/verifier/dummy"
+
+# Benchmarks the steady-state success path for Kitchen::Verifier::Dummy#call.
+ITERATIONS = Integer(ENV.fetch("ITERATIONS", "10000"))
+REPEATS = Integer(ENV.fetch("REPEATS", "7"))
+
+logged_output = StringIO.new
+logger = Logger.new(logged_output)
+platform = OpenStruct.new(os_type: nil, shell_type: nil)
+suite = OpenStruct.new(name: "fries")
+instance = OpenStruct.new(
+  name: "coolbeans",
+  to_str: "instance",
+  logger: logger,
+  suite: suite,
+  platform: platform
+)
+
+config = {
+  test_base_path: "/basist",
+  kitchen_root: "/rooty",
+  sleep: 0,
+  random_failure: false,
+}
+
+verifier = Kitchen::Verifier::Dummy.new(config).finalize_config!(instance)
+state = { baseline: true }
+
+samples_ms = Array.new(REPEATS) do
+  elapsed = Benchmark.realtime do
+    ITERATIONS.times { verifier.call(state) }
+  end
+
+  elapsed * 1000.0
+end
+
+mean = samples_ms.sum / samples_ms.size
+variance = samples_ms.sum { |x| (x - mean) ** 2 } / samples_ms.size
+stddev = Math.sqrt(variance)
+
+puts "Function: Kitchen::Verifier::Dummy#call"
+puts "Iterations per repeat: #{ITERATIONS}"
+puts "Repeats: #{REPEATS}"
+puts format("Mean (ms): %.3f", mean)
+puts format("Stddev (ms): %.3f", stddev)
+puts format("Min (ms): %.3f", samples_ms.min)
+puts format("Max (ms): %.3f", samples_ms.max)
+puts format("Per call mean (us): %.3f", (mean * 1000.0) / ITERATIONS)
+puts "Samples (ms): #{samples_ms.map { |x| format("%.3f", x) }.join(", ")}"

--- a/ai-track-docs/performance-baseline.md
+++ b/ai-track-docs/performance-baseline.md
@@ -1,0 +1,28 @@
+# Ex6 Performance Baseline
+
+## Scope
+- Function benchmarked: `Kitchen::Verifier::Dummy#call`
+- Benchmark script: `ai-track-docs/benchmarks/verifier-dummy-call-benchmark.rb`
+- Mode: success path (`sleep: 0`, `random_failure: false`)
+
+## Run Command
+```bash
+bundle exec ruby ai-track-docs/benchmarks/verifier-dummy-call-benchmark.rb
+```
+
+## Baseline Results
+- Run date: 2026-05-23
+- Iterations per repeat: 10000
+- Repeats: 7
+- Mean: 113.305 ms
+- Stddev: 5.495 ms
+- Min: 109.759 ms
+- Max: 126.440 ms
+- Per-call mean: 11.331 us
+- Raw samples (ms): 126.440, 110.501, 112.896, 109.759, 112.949, 110.237, 110.355
+
+## Variance Notes
+- Micro-benchmarks are sensitive to CPU scheduler noise, thermal throttling, and background load.
+- Ruby JIT settings, GC timing, and process startup overhead can shift measurements.
+- Treat this baseline as relative guidance for future comparisons, not an absolute SLA.
+- The first sample was the highest in this run, which is consistent with warm-up effects.


### PR DESCRIPTION
Summary: Added a minimal micro-benchmark for Kitchen::Verifier::Dummy#call and recorded baseline timings with variance notes.
Evidence: bundle exec ruby ai-track-docs/benchmarks/verifier-dummy-call-benchmark.rb => Mean 113.305 ms, Stddev 5.495 ms, Per-call mean 11.331 us over 7 repeats x 10000 iterations.
Risk: Low
Rollback: revert commit 8e324990