### PR TITLE
GHCP — Crawl: Ex8 security and secret hygiene

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,24 @@ _cache
 docs/public
 .idea/
 docs/.hugo_build.lock
+
+# Secret and credential hygiene
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+*.keystore
+id_rsa
+id_rsa.*
+*.ovpn
+*.kubeconfig
+.npmrc
+.pypirc
+.aws/
+.azure/
+.gcp/
+**/secrets.yml
+**/credentials.yml

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,3 +3,19 @@
 ## Reporting a Vulnerability
 
 See [https://chef.io/security](https://chef.io/security) for our security policy and how to report a vulnerability.
+
+## Secret Hygiene
+
+- Do not commit private keys, tokens, kubeconfigs, cloud credentials, or local `.env` files.
+- Use environment variables, secure secret stores, or local machine keychains for sensitive values.
+- If a secret is found in a branch:
+	- Remove the file/content from the branch immediately.
+	- Rotate/revoke the exposed secret before merge.
+	- Add or tighten ignore patterns to prevent recurrence.
+
+### Common Sensitive File Types
+
+- `*.pem`, `*.key`, `*.p12`, `*.pfx`
+- `.env`, `.env.*`
+- `id_rsa`, `id_rsa.*`
+- `.aws/`, `.azure/`, `.gcp/`


### PR DESCRIPTION
Summary: Improved secret hygiene by adding common secret-file ignores, expanding security notes, and remediating an obvious risk by preventing accidental commit of a detected local private key file path.
Evidence: git check-ignore -v optum_triage/ashique-rsa.pem -> .gitignore:*.pem match; updated .gitignore and SECURITY.md.
Risk: Low
Rollback: revert commit 0229bd89