### PR TITLE
GHCP — Crawl: Ex9 structured logging

### DIFF
--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -58,3 +58,21 @@ bundle exec cucumber features/some_feature.feature
 	- Prefer tagged releases over `branch: main` for reproducibility when feasible.
 
 See `ai-track-docs/dependency-hygiene.md` for Ex7-specific baseline notes and proposals.
+
+## Viewing Structured Logs
+Structured verifier logs include consistent key/value fields:
+- `op`
+- `status`
+- `elapsed_ms`
+
+Run with log output enabled:
+
+```bash
+KITCHEN_LOG=info bundle exec kitchen verify <instance>
+```
+
+Then filter structured fields from the Kitchen log:
+
+```bash
+grep -E "op=verify status=|elapsed_ms=" .kitchen/logs/kitchen.log
+```

--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -35,11 +35,22 @@ module Kitchen
 
       # (see Base#call)
       def call(state)
-        validate_state!(state)
-        info("[#{name}] Verify on instance=#{instance} with state=#{state}")
-        sleep_if_set
-        failure_if_set
-        debug("[#{name}] Verify completed (#{config[:sleep]}s).")
+        started_at = monotonic_time
+        status = "success"
+
+        begin
+          validate_state!(state)
+          info("[#{name}] Verify on instance=#{instance} with state=#{state}")
+          sleep_if_set
+          failure_if_set
+          debug("[#{name}] Verify completed (#{config[:sleep]}s).")
+        rescue StandardError
+          status = "failed"
+          raise
+        ensure
+          elapsed_ms = ((monotonic_time - started_at) * 1000.0).round(3)
+          info("op=verify status=#{status} elapsed_ms=#{elapsed_ms}")
+        end
       end
 
       private
@@ -90,6 +101,14 @@ module Kitchen
       # @api private
       def randomly_fail?
         [true, false].sample
+      end
+
+      # Monotonic clock helper for elapsed-time calculations.
+      #
+      # @return [Float]
+      # @api private
+      def monotonic_time
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
     end
   end

--- a/spec/kitchen/verifier/dummy_spec.rb
+++ b/spec/kitchen/verifier/dummy_spec.rb
@@ -110,5 +110,11 @@ describe Kitchen::Verifier::Dummy do
 
       _(logged_output.string).must_match(/^.+ INFO .+ \[Dummy\] Verify on .+$/)
     end
+
+    it "logs structured verify fields" do
+      verifier.call(state)
+
+      _(logged_output.string).must_match(/op=verify status=success elapsed_ms=\d+(\.\d+)?/)
+    end
   end
 end


### PR DESCRIPTION
Summary: Added structured logging to verifier call path with consistent fields (op, status, elapsed_ms) and documented how to view logs.
Evidence: bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb (12 runs, 15 assertions, 0 failures, 0 errors, 0 skips)
Risk: Low
Rollback: revert commit 2ba3216d