### PR TITLE
GHCP — Crawl: Ex10 CI baseline

### DIFF
--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -42,6 +42,31 @@ bundle exec cucumber features/some_feature.feature
 - Run `rake quality` before opening a PR.
 - Include failing and passing command output snippets in PR evidence when relevant.
 
+## CI Baseline
+Hosted CI exists in this repository (for example [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) and Expeditor pipelines). For reliable local parity, run:
+
+```bash
+./support/ci-baseline.sh
+```
+
+What it does:
+- sets deterministic CI-like environment variables
+- configures local bundler path and installs deps
+- runs unit tests (`bundle exec rake unit`)
+- runs focused verifier regression spec
+
+Optional style step:
+- set `RUN_STYLE=1` to include `bundle exec rake style`
+
+Fast path when dependencies are already installed:
+
+```bash
+SKIP_BUNDLE_INSTALL=1 ./support/ci-baseline.sh
+
+# Include style checks when local tooling supports it
+RUN_STYLE=1 SKIP_BUNDLE_INSTALL=1 ./support/ci-baseline.sh
+```
+
 ## Dependency Notes
 - Core manifests:
 	- `Gemfile`

--- a/support/ci-baseline.sh
+++ b/support/ci-baseline.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Local CI baseline runner for consistent pre-PR validation.
+# This does not replace hosted CI; it provides a reliable local baseline.
+
+set -euo pipefail
+
+export CI="${CI:-true}"
+export LANG=C.UTF-8
+export LANGUAGE=C.UTF-8
+
+echo "==> Local CI baseline starting"
+echo "==> Ruby: $(ruby --version)"
+echo "==> Bundler: $(bundle --version)"
+
+if [[ "${SKIP_BUNDLE_INSTALL:-0}" != "1" ]]; then
+  echo "==> Configuring bundler path"
+  bundle config --local path vendor/bundle
+
+  echo "==> Installing dependencies"
+  bundle install --jobs=7 --retry=3
+else
+  echo "==> SKIP_BUNDLE_INSTALL=1 set; skipping dependency install"
+fi
+
+if [[ "${RUN_STYLE:-0}" == "1" ]]; then
+  echo "==> Running style checks"
+  bundle exec rake style
+else
+  echo "==> RUN_STYLE=0; skipping style checks"
+fi
+
+echo "==> Running unit tests"
+bundle exec rake unit
+
+echo "==> Running focused verifier regression"
+bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb
+
+echo "==> Local CI baseline passed"


### PR DESCRIPTION
Summary: Added a local CI baseline script and documentation to run deterministic pre-PR validation when hosted CI is unavailable or to reproduce CI checks locally.
Evidence: SKIP_BUNDLE_INSTALL=1 ./support/ci-baseline.sh completed with unit suite passing (1943 runs, 2821 assertions, 0 failures) and focused verifier spec passing (12 runs, 15 assertions, 0 failures).
Risk: Low
Rollback: revert commit 56c686f6