### PR TITLE
GHCP — Crawl: Ex13 feature flag

### DIFF
--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -90,6 +90,10 @@ Structured verifier logs include consistent key/value fields:
 - `status`
 - `elapsed_ms`
 
+Feature flag:
+- `structured_logs` (default `true`) on `Kitchen::Verifier::Dummy`
+- Set `structured_logs: false` in verifier config to disable structured log emission.
+
 Run with log output enabled:
 
 ```bash

--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -32,6 +32,7 @@ module Kitchen
 
       default_config :sleep, 0
       default_config :random_failure, false
+      default_config :structured_logs, true
 
       # (see Base#call)
       def call(state)
@@ -49,7 +50,7 @@ module Kitchen
           raise
         ensure
           elapsed_ms = ((monotonic_time - started_at) * 1000.0).round(3)
-          info("op=verify status=#{status} elapsed_ms=#{elapsed_ms}")
+          emit_structured_log(status, elapsed_ms)
         end
       end
 
@@ -101,6 +102,17 @@ module Kitchen
       # @api private
       def randomly_fail?
         [true, false].sample
+      end
+
+      # Emit structured verify log line when feature flag is enabled.
+      #
+      # @param status [String]
+      # @param elapsed_ms [Float]
+      # @api private
+      def emit_structured_log(status, elapsed_ms)
+        return unless config[:structured_logs]
+
+        info("op=verify status=#{status} elapsed_ms=#{elapsed_ms}")
       end
 
       # Monotonic clock helper for elapsed-time calculations.

--- a/spec/kitchen/verifier/dummy_spec.rb
+++ b/spec/kitchen/verifier/dummy_spec.rb
@@ -63,6 +63,10 @@ describe Kitchen::Verifier::Dummy do
     it "sets :random_failure to false by default" do
       _(verifier[:random_failure]).must_equal false
     end
+
+    it "sets :structured_logs to true by default" do
+      _(verifier[:structured_logs]).must_equal true
+    end
   end
 
   describe "#call" do
@@ -112,9 +116,17 @@ describe Kitchen::Verifier::Dummy do
     end
 
     it "logs structured verify fields" do
+      config[:structured_logs] = true
       verifier.call(state)
 
       _(logged_output.string).must_match(/op=verify status=success elapsed_ms=\d+(\.\d+)?/)
+    end
+
+    it "does not log structured verify fields when feature flag is disabled" do
+      config[:structured_logs] = false
+      verifier.call(state)
+
+      _(logged_output.string).wont_match(/op=verify status=success elapsed_ms=\d+(\.\d+)?/)
     end
   end
 end


### PR DESCRIPTION
Summary: Added a safe feature flag around non-critical structured log emission in dummy verifier, with explicit ON/OFF tests and brief documentation.
Evidence: bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb (14 runs, 18 assertions, 0 failures, 0 errors, 0 skips)
Risk: Low
Rollback: revert commit 0cf0394d