### PR TITLE
GHCP — Crawl: Ex14 static analysis

### DIFF
--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -105,3 +105,21 @@ Then filter structured fields from the Kitchen log:
 ```bash
 grep -E "op=verify status=|elapsed_ms=" .kitchen/logs/kitchen.log
 ```
+
+## Static Analysis
+CI already runs lint/static-analysis checks in `.github/workflows/lint.yml`.
+
+Local equivalents:
+
+```bash
+# Full Ruby static analysis
+bundle exec cookstyle --chefstyle --display-cop-names
+
+# Targeted path
+bundle exec cookstyle --chefstyle --display-cop-names lib/kitchen/verifier/dummy.rb spec/kitchen/verifier/dummy_spec.rb
+
+# Unit gate used by lint workflow
+bundle exec rake unit --trace
+```
+
+See `ai-track-docs/static-analysis.md` for the full Ex14 baseline and local runbook.

--- a/ai-track-docs/static-analysis.md
+++ b/ai-track-docs/static-analysis.md
@@ -1,0 +1,46 @@
+# Static Analysis Baseline (Ex14)
+
+Linting/static-analysis checks already exist in CI and are strict enough for routine work.
+
+## Current Checks in CI
+Defined in `.github/workflows/lint.yml`:
+- Ruby style: `cookstyle --chefstyle --display-cop-names`
+- YAML lint: `yamllint`
+- Markdown lint: `markdownlint-cli2`
+- Markdown link checks
+- Unit tests in lint workflow (`bundle exec rake unit --trace`)
+
+## Local Run Commands
+### Ruby static analysis (full)
+```bash
+bundle exec cookstyle --chefstyle --display-cop-names
+```
+
+### Ruby static analysis (targeted path)
+```bash
+bundle exec cookstyle --chefstyle --display-cop-names lib/kitchen/verifier/dummy.rb spec/kitchen/verifier/dummy_spec.rb
+```
+
+### YAML lint
+```bash
+yamllint .
+```
+
+### Markdown lint
+```bash
+npx markdownlint-cli2 "*.md"
+```
+
+### Unit test gate used by lint workflow
+```bash
+bundle exec rake unit --trace
+```
+
+## Current Targeted Path Result
+Targeted cookstyle run for verifier path:
+- Files: `lib/kitchen/verifier/dummy.rb`, `spec/kitchen/verifier/dummy_spec.rb`
+- Result: `2 files inspected, no offenses detected`
+
+## Practical Notes
+- Prefer targeted lint during development, then run full lint before PR.
+- If local lint tooling is missing, install the relevant tool and rerun with `bundle exec` where applicable.


### PR DESCRIPTION
Summary: Linting is already strict in CI, so this change documents current static-analysis checks and local run commands, including targeted path analysis.
Evidence: bundle exec cookstyle --chefstyle --display-cop-names lib/kitchen/verifier/dummy.rb spec/kitchen/verifier/dummy_spec.rb => 2 files inspected, no offenses detected.
Risk: Low
Rollback: revert commit cd705f2f