### PR TITLE
GHCP — Crawl: Ex15 resilience and failure tests

### DIFF
--- a/ai-track-docs/build-test.md
+++ b/ai-track-docs/build-test.md
@@ -94,6 +94,10 @@ Feature flag:
 - `structured_logs` (default `true`) on `Kitchen::Verifier::Dummy`
 - Set `structured_logs: false` in verifier config to disable structured log emission.
 
+Resilience settings (default behavior unchanged):
+- `failure_retries` (default `0`): retry count for `ActionFailed` in dummy verify path.
+- `retry_backoff_ms` (default `0`): backoff between retries in milliseconds.
+
 Run with log output enabled:
 
 ```bash

--- a/lib/kitchen/verifier/dummy.rb
+++ b/lib/kitchen/verifier/dummy.rb
@@ -33,6 +33,8 @@ module Kitchen
       default_config :sleep, 0
       default_config :random_failure, false
       default_config :structured_logs, true
+      default_config :failure_retries, 0
+      default_config :retry_backoff_ms, 0
 
       # (see Base#call)
       def call(state)
@@ -42,8 +44,7 @@ module Kitchen
         begin
           validate_state!(state)
           info("[#{name}] Verify on instance=#{instance} with state=#{state}")
-          sleep_if_set
-          failure_if_set
+          run_verify_with_retries
           debug("[#{name}] Verify completed (#{config[:sleep]}s).")
         rescue StandardError
           status = "failed"
@@ -74,6 +75,28 @@ module Kitchen
         elsif config[:random_failure] && randomly_fail?
           debug("Random failure for Verifier #{name}.")
           fail_verify!
+        end
+      end
+
+      # Execute verify behavior with optional retry/backoff for transient
+      # failures. Defaults keep existing behavior (no retries).
+      #
+      # @api private
+      def run_verify_with_retries
+        retries = Integer(config[:failure_retries] || 0)
+        retries = 0 if retries.negative?
+        attempts = 0
+
+        begin
+          sleep_if_set
+          failure_if_set
+        rescue ActionFailed
+          attempts += 1
+          raise if attempts > retries
+
+          backoff_seconds = [config[:retry_backoff_ms].to_f, 0.0].max / 1000.0
+          sleep(backoff_seconds) if backoff_seconds.positive?
+          retry
         end
       end
 

--- a/spec/kitchen/verifier/dummy_spec.rb
+++ b/spec/kitchen/verifier/dummy_spec.rb
@@ -67,6 +67,14 @@ describe Kitchen::Verifier::Dummy do
     it "sets :structured_logs to true by default" do
       _(verifier[:structured_logs]).must_equal true
     end
+
+    it "sets :failure_retries to 0 by default" do
+      _(verifier[:failure_retries]).must_equal 0
+    end
+
+    it "sets :retry_backoff_ms to 0 by default" do
+      _(verifier[:retry_backoff_ms]).must_equal 0
+    end
   end
 
   describe "#call" do
@@ -127,6 +135,24 @@ describe Kitchen::Verifier::Dummy do
       verifier.call(state)
 
       _(logged_output.string).wont_match(/op=verify status=success elapsed_ms=\d+(\.\d+)?/)
+    end
+
+    it "retries failed verify when :failure_retries is enabled" do
+      config[:fail] = true
+      config[:failure_retries] = 1
+      verifier.expects(:fail_verify!).twice.raises(Kitchen::ActionFailed.new("boom"))
+
+      _ { verifier.call(state) }.must_raise Kitchen::ActionFailed
+    end
+
+    it "applies retry backoff when configured" do
+      config[:fail] = true
+      config[:failure_retries] = 1
+      config[:retry_backoff_ms] = 25
+      verifier.expects(:sleep).with(0.025).once
+      verifier.expects(:fail_verify!).twice.raises(Kitchen::ActionFailed.new("boom"))
+
+      _ { verifier.call(state) }.must_raise Kitchen::ActionFailed
     end
   end
 end


### PR DESCRIPTION
Summary: Added minimal retry/backoff resilience to dummy verifier failure path with safe defaults and added failure-focused tests, plus brief docs.
Evidence: bundle exec ruby -I spec spec/kitchen/verifier/dummy_spec.rb (18 runs, 25 assertions, 0 failures, 0 errors, 0 skips)
Risk: Low
Rollback: revert commit a59713d5