### PR TITLE
CHEF-34831: Use appbundler for binstub generation and fix code scan

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -9,7 +9,7 @@ $env:HAB_BLDR_CHANNEL = 'base-2025'
 $env:HAB_REFRESH_CHANNEL = "base-2025"
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
-$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '1.6.1245' }
+$HabitatVersion = $env:HAB_VERSION
 $Plan = 'chef-test-kitchen-enterprise'
 
 Write-Host "--- system details"
@@ -29,15 +29,26 @@ function Stop-HabProcess {
 # Installing Habitat
 function Install-Habitat {
   param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string]$Version
   )
-  Write-Host "Downloading and installing Habitat version $Version..."
+  if ($Version) {
+    Write-Host "Downloading and installing Habitat version $Version..."
+  }
+  else {
+    Write-Host "Downloading and installing latest Habitat version..."
+  }
   $installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
-  $installScriptPath = Join-Path $env:TEMP "hab-install-$Version.ps1"
+  $scriptSuffix = if ($Version) { $Version } else { "latest" }
+  $installScriptPath = Join-Path $env:TEMP "hab-install-$scriptSuffix.ps1"
   Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
   try {
-    & $installScriptPath -Version $Version
+    if ($Version) {
+      & $installScriptPath -Version $Version
+    }
+    else {
+      & $installScriptPath
+    }
   }
   finally {
     Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,10 @@ group :cookstyle do
   gem "cookstyle", ">= 8.2", "< 9.0"
 end
 
+group :packaging do
+  gem "appbundler"
+end
+
 group :test do
   gem "rb-readline"
   gem "aruba",     ">= 0.11", "< 3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
 
 gemspec name: 'chef-test-kitchen-enterprise'
-gemspec name: 'test-kitchen' # Alias gemspec to satisfy transitive dependencies on test-kitchen
+# The alias gemspec is present in the repository root, but not inside the
+# installed chef-test-kitchen-enterprise gem payload used by appbundler.
+gemspec name: 'test-kitchen' if File.exist?(File.expand_path('test-kitchen.gemspec', __dir__))
 
 # net-ssh 7.3.1 has a regression in Net::SSH::Test::Extensions::PacketStream#idle!
 # where StringIO#string= resets pos to 0 before self.pos = pos can restore it,

--- a/habitat/binstub_patch.bat
+++ b/habitat/binstub_patch.bat
@@ -1,0 +1,14 @@
+REM skip this if hab pkg exec has already done it, APPBUNDLER_ALLOW_RVM will be set if hab pkg exec
+IF NOT DEFINED APPBUNDLER_ALLOW_RVM (
+  IF EXIST "%~dp0..\RUNTIME_ENVIRONMENT" (
+    FOR /F "usebackq tokens=* delims=" %%A IN ("%~dp0..\RUNTIME_ENVIRONMENT") DO (
+      SET "line=%%A"
+      REM Skip empty lines and comments
+      IF NOT "!line!"=="" (
+        IF NOT "!line:~0,1!"=="#" (
+          SET "%%A"
+        )
+      )
+    )
+  )
+)

--- a/habitat/binstub_patch.rb
+++ b/habitat/binstub_patch.rb
@@ -1,0 +1,4 @@
+unless ENV["APPBUNDLER_ALLOW_RVM"]
+  ENV["APPBUNDLER_ALLOW_RVM"] = "true"
+  ENV["GEM_PATH"] = [File.expand_path(File.join(__dir__, "..", "vendor")), ENV["GEM_PATH"]].compact.join(File::PATH_SEPARATOR)
+end

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -127,6 +127,15 @@ function Invoke-Install {
         & $rubyExe $appbundler $project_root "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
         if ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
 
+        Write-BuildLine "** patching generated binstubs for Habitat runtime env"
+        $binstubPatch = Get-Content "$PLAN_CONTEXT\binstub_patch.bat" -Raw
+        Get-ChildItem -Path "$pkg_prefix\bin\*.bat" -File | ForEach-Object {
+            $binstubPath = $_.FullName
+            $binstubContent = Get-Content $binstubPath -Raw
+            $binstubContent = $binstubContent -replace '(?im)^@ECHO OFF', "@ECHO OFF`r`n$binstubPatch"
+            Set-Content -Path $binstubPath -Value $binstubContent -Encoding ASCII -NoNewline
+        }
+
 	Write-BuildLine " ** Build and install complete"
 
         If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -111,33 +111,21 @@ function Invoke-Install {
             Exit 1
         }
 
-        # Set GEM_PATH to include both vendor and the system gem paths
+        # Ensure appbundler and installed gems resolve from the packaged vendor path.
         $env:GEM_PATH = "$pkg_prefix/vendor"
         $env:GEM_HOME = "$pkg_prefix/vendor"
 
-        # Create bin directory if it doesn't exist
         if (-not (Test-Path "$pkg_prefix/bin")) {
             New-Item -ItemType Directory -Path "$pkg_prefix/bin" | Out-Null
         }
 
-        # Find the gem and create wrapper for kitchen binary
-        $kitchenGemDir = Get-ChildItem "$pkg_prefix/vendor/gems" -Filter "chef-test-kitchen-enterprise-*" -Directory | Select-Object -First 1
-        if ($kitchenGemDir) {
-            Write-BuildLine "** Found gem directory: $($kitchenGemDir.FullName)"
-            $realKitchenBin = "$($kitchenGemDir.FullName)/bin/kitchen"
-            if (Test-Path $realKitchenBin) {
-                Write-BuildLine "** Creating wrapper for kitchen binary"
+        $rubyPkgPath = (& hab pkg path core/ruby3_4-plus-devkit).Trim()
+        $rubyExe = Join-Path $rubyPkgPath "bin\ruby.exe"
+        $appbundler = Join-Path $pkg_prefix "vendor\bin\appbundler"
 
-                # Remove any existing kitchen files in bin directory
-                Remove-Item "$pkg_prefix/bin/kitchen" -Force -ErrorAction SilentlyContinue
-                Remove-Item "$pkg_prefix/bin/kitchen.bat" -Force -ErrorAction SilentlyContinue
-
-                # Remove kitchen from vendor/bin if it exists (to avoid conflicts)
-                Remove-Item "$pkg_prefix/vendor/bin/kitchen" -Force -ErrorAction SilentlyContinue
-
-                Wrap-KitchenBinary "$pkg_prefix/bin/kitchen" $realKitchenBin
-            }
-        }
+        Write-BuildLine "** generating binstubs for chef-test-kitchen-enterprise with precise version pins"
+        & $rubyExe $appbundler $project_root "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
+        if ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
 
 	Write-BuildLine " ** Build and install complete"
 
@@ -145,52 +133,6 @@ function Invoke-Install {
     } finally {
         Pop-Location
     }
-}
-
-function Wrap-KitchenBinary {
-    param(
-        [string]$WrapperPath,
-        [string]$RealBinPath
-    )
-
-    Write-BuildLine "Creating wrapper script at $WrapperPath"
-
-    # Get the path from PKG_PREFIX to the gem directory
-    $kitchenBinPath = "vendor\gems\$($pkg_name)-$($pkg_version)\bin\kitchen"
-
-    # Create a batch wrapper script that sets up the environment using runtime paths
-    $wrapperContent = @"
-@echo off
-setlocal enabledelayedexpansion
-REM Wrapper script for Test Kitchen Enterprise
-REM Sets up Ruby gem environment and executes kitchen
-
-REM Get the package prefix from the script location
-for %%I in ("%~dp0..") do set "PKG_PREFIX=%%~fI"
-
-REM Use hab to find the Ruby installation path
-for /f "delims=" %%i in ('hab pkg path core/ruby3_4-plus-devkit 2^>nul') do set "RUBY_PATH=%%i"
-
-if not defined RUBY_PATH (
-    echo ERROR: Could not find Ruby installation. Run: hab pkg install core/ruby3_4-plus-devkit
-    exit /b 1
-)
-
-REM Set Ruby paths for gem loading - include both vendor and Ruby system gems
-set "GEM_HOME=%PKG_PREFIX%\vendor"
-set "GEM_PATH=%PKG_PREFIX%\vendor;%RUBY_PATH%\lib\ruby\gems\3.4.0"
-
-REM Set encoding to UTF-8 to handle non-ASCII characters
-set "RUBYOPT=-Eutf-8"
-
-REM Execute the real kitchen binary with ruby
-"%RUBY_PATH%\bin\ruby.exe" "%PKG_PREFIX%\$kitchenBinPath" %*
-"@
-
-    # On Windows, only create .bat file for compatibility
-    Set-Content -Path "$WrapperPath.bat" -Value $wrapperContent -Encoding ASCII
-
-    Write-BuildLine "Wrapper created successfully at $WrapperPath.bat"
 }
 
 function Invoke-After {
@@ -206,6 +148,9 @@ function Invoke-After {
     # Remove the byproducts of compiling gems with extensions
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
+    # Remove vendored .github directories to reduce scanner false positives.
+    Get-ChildItem $pkg_prefix/vendor -Filter ".github" -Directory -Recurse -ErrorAction SilentlyContinue `
+        | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 function Install-ChefOfficialDistribution {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -55,6 +55,11 @@ do_build() {
   bundle config --local silence_root_warning 1
 
   bundle install
+  # appbundler requires Gemfile.lock in BUNDLE_DIR. Generate it only when missing
+  # so this stays aligned with chef pattern if a lockfile is later committed.
+  if [[ ! -f Gemfile.lock ]]; then
+    bundle lock
+  fi
   ruby ./cleanup_lint_roller.rb
   ruby ./post-bundle-install.rb
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -12,6 +12,7 @@ pkg_bin_dirs=(
 pkg_build_deps=(
   core/make
   core/bash
+  core/sed
   core/gcc
   core/git
 )
@@ -82,43 +83,18 @@ do_install() {
 
   make_pkg_official_distrib
 
-  wrap_ruby_kitchen
+  build_line "Generating appbundler binstubs with precise version pins"
+  "$(pkg_path_for $_ruby_pkg)/bin/ruby" "$pkg_prefix/vendor/bin/appbundler" "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
+
+  build_line "Patching generated binstubs for Habitat runtime env"
+  for binstub in "$pkg_prefix"/bin/*; do
+    if [[ -f "$binstub" ]]; then
+      sed -i "/require \"rubygems\"/r $PLAN_CONTEXT/binstub_patch.rb" "$binstub"
+    fi
+  done
+
   set_runtime_env "GEM_PATH" "${pkg_prefix}/vendor"
-}
-
-wrap_ruby_kitchen() {
-  local bin="$pkg_prefix/bin/kitchen"
-  local real_bin="$GEM_HOME/gems/chef-test-kitchen-enterprise-$(pkg_version)/bin/kitchen"
-  wrap_bin_with_ruby "$bin" "$real_bin"
-}
-
-wrap_bin_with_ruby() {
-  local bin="$1"
-  local real_bin="$2"
-  local ruby_default_gem_dir
-
-  # Include the packaged Ruby's default gem directory in GEM_PATH.
-  ruby_default_gem_dir="$(env -u GEM_HOME -u GEM_PATH "$(pkg_path_for $_ruby_pkg)/bin/ruby" -rrubygems -e 'puts Gem.default_dir')"
-  build_line "Detected Ruby default gem dir: ${ruby_default_gem_dir}"
-
-  build_line "Adding wrapper $bin to $real_bin"
-  cat <<EOF > "$bin"
-#!$(pkg_path_for core/bash)/bin/bash
-set -e
-
-# Set binary path that allows chef-test-kitchen-enterprise to use non-Hab pkg binaries
-export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
-
-# Set Ruby paths defined from 'do_setup_environment()'
-export GEM_HOME="$pkg_prefix/vendor"
-export GEM_PATH="\$GEM_HOME:${ruby_default_gem_dir}"
-
-# Set encoding to UTF-8 to handle non-ASCII characters in gem files
-export RUBYOPT="-Eutf-8"
-
-exec $(pkg_path_for $_ruby_pkg)/bin/ruby $real_bin \$@
-EOF
-  chmod -v 755 "$bin"
+  set_runtime_env "APPBUNDLER_ALLOW_RVM" "true"
 }
 
 make_pkg_official_distrib() {
@@ -127,6 +103,11 @@ make_pkg_official_distrib() {
   gem source --add "https://artifactory-internal.ps.chef.co/artifactory/omnibus-gems-local/"
   gem install chef-official-distribution --no-document --install-dir "$GEM_HOME" --ignore-dependencies
   gem sources -r "https://artifactory-internal.ps.chef.co/artifactory/omnibus-gems-local/"
+}
+
+do_after() {
+  build_line "Removing .github directories from vendored gems"
+  find "$pkg_prefix/vendor" -type d -name ".github" -exec rm -rf {} + 2>/dev/null || true
 }
 
 do_strip() {


### PR DESCRIPTION
## Summary

- Use appbundler for binstub generation with precise version pins
- Add binstub_patch.rb (chef pattern) to bootstrap GEM_HOME/GEM_PATH when invoked via binlink
- Fix step-security/harden-runner alerts by removing .github dirs from vendored gems
- Remove hardcoded hab version in Windows test script

## Changes

| File | Change |
| --- | --- |
| habitat/plan.sh | Replace manual wrapper with appbundler + binstub_patch and add vendored .github cleanup |
| habitat/plan.ps1 | Use appbundler for Windows binstub generation and add vendored .github cleanup |
| habitat/binstub_patch.rb | Add chef-pattern patch file for GEM_PATH bootstrapping |
| .expeditor/buildkite/artifact.habitat.test.ps1 | Use latest Habitat by default; keep HAB_VERSION override |
| Gemfile | Add appbundler in packaging group |

## Code Scan Fixed

- GHSA-46g3-37rh-v698 (step-security/harden-runner)
- GHSA-g699-3x6g-wm3g (step-security/harden-runner)
- GHSA-cpmj-h4f6-r6pq (step-security/harden-runner)

## Testing

- bash -n habitat/plan.sh
- ruby -c habitat/binstub_patch.rb
- Verified no editor diagnostics on changed files
