### PR TITLE
CHEF-35087 - Use appbundler in hab packaging and install latest Habitat in Windows test

### DIFF
--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -9,7 +9,6 @@ $env:HAB_BLDR_CHANNEL = 'base-2025'
 $env:HAB_REFRESH_CHANNEL = "base-2025"
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
-$HabitatVersion = $env:HAB_VERSION
 $Plan = 'chef-test-kitchen-enterprise'
 
 Write-Host "--- system details"
@@ -28,31 +27,8 @@ function Stop-HabProcess {
 
 # Installing Habitat
 function Install-Habitat {
-  param(
-    [Parameter(Mandatory = $false)]
-    [string]$Version
-  )
-  if ($Version) {
-    Write-Host "Downloading and installing Habitat version $Version..."
-  }
-  else {
-    Write-Host "Downloading and installing latest Habitat version..."
-  }
-  $installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
-  $scriptSuffix = if ($Version) { $Version } else { "latest" }
-  $installScriptPath = Join-Path $env:TEMP "hab-install-$scriptSuffix.ps1"
-  Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
-  try {
-    if ($Version) {
-      & $installScriptPath -Version $Version
-    }
-    else {
-      & $installScriptPath
-    }
-  }
-  finally {
-    Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue
-  }
+  Write-Host "Downloading and installing Habitat..."
+  Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'))
 }
 
 try {
@@ -75,7 +51,7 @@ catch {
       }
   }
 
-  Install-Habitat -Version $HabitatVersion
+  Install-Habitat
 }
 finally {
   Write-Host "******************************************************************"
@@ -92,9 +68,6 @@ Write-Host "--- Generating fake origin key"
 hab origin key generate $env:HAB_ORIGIN
 
 Write-Host "--- Building $Plan"
-Write-Host "******************************************************************"
-Write-Host "** What is My Project Root as determined by git rev? $(git rev-parse --show-toplevel)"
-Write-Host "******************************************************************"
 $project_root = "$(git rev-parse --show-toplevel)"
 Set-Location $project_root
 

--- a/.expeditor/buildkite/artifact.habitat.test.ps1
+++ b/.expeditor/buildkite/artifact.habitat.test.ps1
@@ -9,7 +9,7 @@ $env:HAB_BLDR_CHANNEL = 'base-2025'
 $env:HAB_REFRESH_CHANNEL = "base-2025"
 $env:CHEF_LICENSE = 'accept-no-persist'
 $env:HAB_LICENSE = 'accept-no-persist'
-$HabitatVersion = if ($env:HAB_VERSION) { $env:HAB_VERSION } else { '1.6.1245' }
+$HabitatVersion = $env:HAB_VERSION
 $Plan = 'chef-test-kitchen-enterprise'
 
 Write-Host "--- system details"
@@ -29,15 +29,26 @@ function Stop-HabProcess {
 # Installing Habitat
 function Install-Habitat {
   param(
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $false)]
     [string]$Version
   )
-  Write-Host "Downloading and installing Habitat version $Version..."
+  if ($Version) {
+    Write-Host "Downloading and installing Habitat version $Version..."
+  }
+  else {
+    Write-Host "Downloading and installing latest Habitat version..."
+  }
   $installScriptUrl = 'https://raw.githubusercontent.com/habitat-sh/habitat/main/components/hab/install.ps1'
-  $installScriptPath = Join-Path $env:TEMP "hab-install-$Version.ps1"
+  $scriptSuffix = if ($Version) { $Version } else { "latest" }
+  $installScriptPath = Join-Path $env:TEMP "hab-install-$scriptSuffix.ps1"
   Invoke-WebRequest -Uri $installScriptUrl -OutFile $installScriptPath
   try {
-    & $installScriptPath -Version $Version
+    if ($Version) {
+      & $installScriptPath -Version $Version
+    }
+    else {
+      & $installScriptPath
+    }
   }
   finally {
     Remove-Item $installScriptPath -Force -ErrorAction SilentlyContinue

--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,10 @@ group :cookstyle do
   gem "cookstyle", ">= 8.2", "< 9.0"
 end
 
+group :packaging do
+  gem "appbundler"
+end
+
 group :test do
   gem "rb-readline"
   gem "aruba",     ">= 0.11", "< 3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -75,4 +75,3 @@ group :test do
   gem "mocha",     ">= 2.0", "< 4.0"
   gem "irb"
 end
-gem "chef-test-kitchen-enterprise"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec name: 'chef-test-kitchen-enterprise'
 # The alias gemspec is present in the repository root, but not inside the
 # installed chef-test-kitchen-enterprise gem payload used by appbundler.
-gemspec name: 'test-kitchen' if File.exist?(File.expand_path('test-kitchen.gemspec', __dir__)) && ENV["CHEF_TEST_KITCHEN_ENTERPRISE"] != "true"
+gemspec name: 'test-kitchen' if File.exist?(File.expand_path('test-kitchen.gemspec', __dir__))
 
 # net-ssh 7.3.1 has a regression in Net::SSH::Test::Extensions::PacketStream#idle!
 # where StringIO#string= resets pos to 0 before self.pos = pos can restore it,
@@ -60,6 +60,7 @@ end
 
 group :packaging do
   gem "appbundler"
+  gem "racc"
 end
 
 group :test do
@@ -74,3 +75,4 @@ group :test do
   gem "mocha",     ">= 2.0", "< 4.0"
   gem "irb"
 end
+gem "chef-test-kitchen-enterprise"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
 
 gemspec name: 'chef-test-kitchen-enterprise'
-gemspec name: 'test-kitchen' # Alias gemspec to satisfy transitive dependencies on test-kitchen
+# The alias gemspec is present in the repository root, but not inside the
+# installed chef-test-kitchen-enterprise gem payload used by appbundler.
+gemspec name: 'test-kitchen' if File.exist?(File.expand_path('test-kitchen.gemspec', __dir__))
 
 # net-ssh 7.3.1 has a regression in Net::SSH::Test::Extensions::PacketStream#idle!
 # where StringIO#string= resets pos to 0 before self.pos = pos can restore it,

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ end
 
 group :packaging do
   gem "appbundler"
-  gem "racc"
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gemspec name: 'chef-test-kitchen-enterprise'
 # The alias gemspec is present in the repository root, but not inside the
 # installed chef-test-kitchen-enterprise gem payload used by appbundler.
-gemspec name: 'test-kitchen' if File.exist?(File.expand_path('test-kitchen.gemspec', __dir__))
+gemspec name: 'test-kitchen' if File.exist?(File.expand_path('test-kitchen.gemspec', __dir__)) && ENV["CHEF_TEST_KITCHEN_ENTERPRISE"] != "true"
 
 # net-ssh 7.3.1 has a regression in Net::SSH::Test::Extensions::PacketStream#idle!
 # where StringIO#string= resets pos to 0 before self.pos = pos can restore it,

--- a/habitat/binstub_patch.bat
+++ b/habitat/binstub_patch.bat
@@ -1,0 +1,14 @@
+REM skip this if hab pkg exec has already done it, APPBUNDLER_ALLOW_RVM will be set if hab pkg exec
+IF NOT DEFINED APPBUNDLER_ALLOW_RVM (
+  IF EXIST "%~dp0..\RUNTIME_ENVIRONMENT" (
+    FOR /F "usebackq tokens=* delims=" %%A IN ("%~dp0..\RUNTIME_ENVIRONMENT") DO (
+      SET "line=%%A"
+      REM Skip empty lines and comments
+      IF NOT "!line!"=="" (
+        IF NOT "!line:~0,1!"=="#" (
+          SET "%%A"
+        )
+      )
+    )
+  )
+)

--- a/habitat/binstub_patch.bat
+++ b/habitat/binstub_patch.bat
@@ -1,3 +1,4 @@
+setlocal enabledelayedexpansion
 REM skip this if hab pkg exec has already done it, APPBUNDLER_ALLOW_RVM will be set if hab pkg exec
 IF NOT DEFINED APPBUNDLER_ALLOW_RVM (
   IF EXIST "%~dp0..\RUNTIME_ENVIRONMENT" (

--- a/habitat/binstub_patch.rb
+++ b/habitat/binstub_patch.rb
@@ -1,0 +1,4 @@
+unless ENV["APPBUNDLER_ALLOW_RVM"]
+  ENV["APPBUNDLER_ALLOW_RVM"] = "true"
+  ENV["GEM_PATH"] = [File.expand_path(File.join(__dir__, "..", "vendor")), ENV["GEM_PATH"]].compact.join(File::PATH_SEPARATOR)
+end

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -36,6 +36,7 @@ function Invoke-Build {
         $env:Path += ";c:\\Program Files\\Git\\bin"
         Push-Location $project_root
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
+        $env:CHEF_TEST_KITCHEN_ENTERPRISE = "true"
 
         Write-BuildLine " ** Enabling Windows long path support"
         # Enable Git long paths for bundler git operations
@@ -107,6 +108,7 @@ function Invoke-Install {
 
     try {
         Push-Location $pkg_prefix
+        $env:CHEF_TEST_KITCHEN_ENTERPRISE = "true"
         if (-not (Test-Path "$pkg_prefix/Gemfile.lock")) {
             Write-BuildLine "ERROR: Gemfile.lock still not found in $pkg_prefix"
             Exit 1

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -129,16 +129,19 @@ function Invoke-Install {
             Copy-Item -Path "$pkg_prefix/Gemfile.lock" -Destination (Join-Path $bundleDir "Gemfile.lock") -Force
         }
 
-        # Resolve all gems from the packaged vendor path.
-        $env:GEM_PATH = "$pkg_prefix/vendor"
+        $rubyPkgPath = (& hab pkg path core/ruby3_4-plus-devkit).Trim()
+        $rubyExe = Join-Path $rubyPkgPath "bin\ruby.exe"
+        $defaultGemPath = & $rubyExe -e "require 'rubygems'; print Gem.default_dir"
+
+        # Keep packaged gems first, but include Ruby default gems so appbundler can
+        # resolve stdlib-shipped gems (for example racc on Ruby 3.4).
+        $env:GEM_PATH = "$pkg_prefix/vendor;$defaultGemPath"
         $env:GEM_HOME = "$pkg_prefix/vendor"
 
         if (-not (Test-Path "$pkg_prefix/bin")) {
             New-Item -ItemType Directory -Path "$pkg_prefix/bin" | Out-Null
         }
 
-        $rubyPkgPath = (& hab pkg path core/ruby3_4-plus-devkit).Trim()
-        $rubyExe = Join-Path $rubyPkgPath "bin\ruby.exe"
         $appbundler = Join-Path $pkg_prefix "vendor\bin\appbundler"
 
         Write-BuildLine "** generating binstubs for chef-test-kitchen-enterprise with precise version pins"

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -91,24 +91,40 @@ function Invoke-Install {
                      "*/latest", "latest",
                      "*/JSON-Schema-Test-Suite", "JSON-Schema-Test-Suite")
 
-    # Ensure Gemfile.lock is copied to the package root (it's in src/ subdirectory)
-    Write-BuildLine "** Checking for Gemfile.lock at $HAB_CACHE_SRC_PATH/$pkg_dirname/src/Gemfile.lock"
-    if (Test-Path "$HAB_CACHE_SRC_PATH/$pkg_dirname/src/Gemfile.lock") {
-        Write-BuildLine "** Copying Gemfile.lock to $pkg_prefix/Gemfile.lock"
-        Copy-Item -Path "$HAB_CACHE_SRC_PATH/$pkg_dirname/src/Gemfile.lock" -Destination "$pkg_prefix/Gemfile.lock" -Force
-    } else {
-        Write-BuildLine "** Gemfile.lock not found at expected location, checking alternatives..."
-        Get-ChildItem "$HAB_CACHE_SRC_PATH/$pkg_dirname" -Filter "Gemfile.lock" -Recurse | ForEach-Object {
-            Write-BuildLine "** Found Gemfile.lock at: $($_.FullName)"
-            Copy-Item -Path $_.FullName -Destination "$pkg_prefix/Gemfile.lock" -Force
-        }
+    # Ensure we use the project lockfile (not lockfiles from vendored gems).
+    $projectGemfileLockCandidates = @(
+        "$HAB_CACHE_SRC_PATH/$pkg_dirname/Gemfile.lock",
+        "$HAB_CACHE_SRC_PATH/$pkg_dirname/src/Gemfile.lock",
+        "$project_root/Gemfile.lock"
+    )
+    $projectGemfileLock = $projectGemfileLockCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if (-not $projectGemfileLock) {
+        Write-BuildLine "ERROR: Project Gemfile.lock not found in expected locations"
+        Exit 1
     }
+    Write-BuildLine "** Using project Gemfile.lock from: $projectGemfileLock"
+    Copy-Item -Path $projectGemfileLock -Destination "$pkg_prefix/Gemfile.lock" -Force
 
     try {
         Push-Location $pkg_prefix
         if (-not (Test-Path "$pkg_prefix/Gemfile.lock")) {
             Write-BuildLine "ERROR: Gemfile.lock still not found in $pkg_prefix"
             Exit 1
+        }
+
+        $bundleGemfileCandidates = @(
+            "$HAB_CACHE_SRC_PATH/$pkg_dirname/Gemfile",
+            "$HAB_CACHE_SRC_PATH/$pkg_dirname/src/Gemfile",
+            "$pkg_prefix/Gemfile"
+        )
+        $env:BUNDLE_GEMFILE = $bundleGemfileCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+        if (-not $env:BUNDLE_GEMFILE) {
+            Write-BuildLine "ERROR: Project Gemfile not found in expected locations"
+            Exit 1
+        }
+        $bundleDir = Split-Path -Parent $env:BUNDLE_GEMFILE
+        if (-not (Test-Path (Join-Path $bundleDir "Gemfile.lock"))) {
+            Copy-Item -Path "$pkg_prefix/Gemfile.lock" -Destination (Join-Path $bundleDir "Gemfile.lock") -Force
         }
 
         # Ensure appbundler and installed gems resolve from the packaged vendor path.
@@ -124,7 +140,7 @@ function Invoke-Install {
         $appbundler = Join-Path $pkg_prefix "vendor\bin\appbundler"
 
         Write-BuildLine "** generating binstubs for chef-test-kitchen-enterprise with precise version pins"
-        & $rubyExe $appbundler $project_root "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
+        & $rubyExe $appbundler $bundleDir "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
         if ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
 
         Write-BuildLine "** patching generated binstubs for Habitat runtime env"

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -127,6 +127,15 @@ function Invoke-Install {
         & $rubyExe $appbundler $project_root "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
         if ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
 
+        Write-BuildLine "** patching generated binstubs for Habitat runtime env"
+        $binstubPatch = Get-Content "$PLAN_CONTEXT\binstub_patch.bat" -Raw
+        Get-ChildItem -Path "$pkg_prefix\bin\*.bat" -File | ForEach-Object {
+            $binstubPath = $_.FullName
+            $binstubContent = Get-Content $binstubPath -Raw
+            $binstubContent = $binstubContent -replace '(?im)^@ECHO OFF', "@ECHO OFF`r`n$binstubPatch"
+            Set-Content -Path $binstubPath -Value $binstubContent -Encoding ASCII -NoNewline
+        }
+
 	Write-BuildLine " ** Build and install complete"
 
         If ($lastexitcode -ne 0) { Exit $lastexitcode }

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -93,9 +93,9 @@ function Invoke-Install {
 
     # Ensure we use the project lockfile (not lockfiles from vendored gems).
     $projectGemfileLockCandidates = @(
-        "$HAB_CACHE_SRC_PATH/$pkg_dirname/Gemfile.lock",
-        "$HAB_CACHE_SRC_PATH/$pkg_dirname/src/Gemfile.lock",
-        "$project_root/Gemfile.lock"
+        (Join-Path "$HAB_CACHE_SRC_PATH/$pkg_dirname" "Gemfile.lock"),
+        (Join-Path "$HAB_CACHE_SRC_PATH/$pkg_dirname/src" "Gemfile.lock"),
+        (Join-Path $project_root "Gemfile.lock")
     )
     $projectGemfileLock = $projectGemfileLockCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
     if (-not $projectGemfileLock) {
@@ -103,7 +103,7 @@ function Invoke-Install {
         Exit 1
     }
     Write-BuildLine "** Using project Gemfile.lock from: $projectGemfileLock"
-    Copy-Item -Path $projectGemfileLock -Destination "$pkg_prefix/Gemfile.lock" -Force
+    Copy-Item -Path $projectGemfileLock -Destination (Join-Path $pkg_prefix "Gemfile.lock") -Force
 
     try {
         Push-Location $pkg_prefix
@@ -113,9 +113,10 @@ function Invoke-Install {
         }
 
         $bundleGemfileCandidates = @(
-            "$HAB_CACHE_SRC_PATH/$pkg_dirname/Gemfile",
-            "$HAB_CACHE_SRC_PATH/$pkg_dirname/src/Gemfile",
-            "$pkg_prefix/Gemfile"
+            (Join-Path "$HAB_CACHE_SRC_PATH/$pkg_dirname" "Gemfile"),
+            (Join-Path "$HAB_CACHE_SRC_PATH/$pkg_dirname/src" "Gemfile"),
+            (Join-Path $project_root "Gemfile"),
+            (Join-Path $pkg_prefix "Gemfile")
         )
         $env:BUNDLE_GEMFILE = $bundleGemfileCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
         if (-not $env:BUNDLE_GEMFILE) {

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -111,33 +111,21 @@ function Invoke-Install {
             Exit 1
         }
 
-        # Set GEM_PATH to include both vendor and the system gem paths
+        # Ensure appbundler and installed gems resolve from the packaged vendor path.
         $env:GEM_PATH = "$pkg_prefix/vendor"
         $env:GEM_HOME = "$pkg_prefix/vendor"
 
-        # Create bin directory if it doesn't exist
         if (-not (Test-Path "$pkg_prefix/bin")) {
             New-Item -ItemType Directory -Path "$pkg_prefix/bin" | Out-Null
         }
 
-        # Find the gem and create wrapper for kitchen binary
-        $kitchenGemDir = Get-ChildItem "$pkg_prefix/vendor/gems" -Filter "chef-test-kitchen-enterprise-*" -Directory | Select-Object -First 1
-        if ($kitchenGemDir) {
-            Write-BuildLine "** Found gem directory: $($kitchenGemDir.FullName)"
-            $realKitchenBin = "$($kitchenGemDir.FullName)/bin/kitchen"
-            if (Test-Path $realKitchenBin) {
-                Write-BuildLine "** Creating wrapper for kitchen binary"
+        $rubyPkgPath = (& hab pkg path core/ruby3_4-plus-devkit).Trim()
+        $rubyExe = Join-Path $rubyPkgPath "bin\ruby.exe"
+        $appbundler = Join-Path $pkg_prefix "vendor\bin\appbundler"
 
-                # Remove any existing kitchen files in bin directory
-                Remove-Item "$pkg_prefix/bin/kitchen" -Force -ErrorAction SilentlyContinue
-                Remove-Item "$pkg_prefix/bin/kitchen.bat" -Force -ErrorAction SilentlyContinue
-
-                # Remove kitchen from vendor/bin if it exists (to avoid conflicts)
-                Remove-Item "$pkg_prefix/vendor/bin/kitchen" -Force -ErrorAction SilentlyContinue
-
-                Wrap-KitchenBinary "$pkg_prefix/bin/kitchen" $realKitchenBin
-            }
-        }
+        Write-BuildLine "** generating binstubs for chef-test-kitchen-enterprise with precise version pins"
+        & $rubyExe $appbundler $project_root "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
+        if ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
 
 	Write-BuildLine " ** Build and install complete"
 
@@ -145,52 +133,6 @@ function Invoke-Install {
     } finally {
         Pop-Location
     }
-}
-
-function Wrap-KitchenBinary {
-    param(
-        [string]$WrapperPath,
-        [string]$RealBinPath
-    )
-
-    Write-BuildLine "Creating wrapper script at $WrapperPath"
-
-    # Get the path from PKG_PREFIX to the gem directory
-    $kitchenBinPath = "vendor\gems\$($pkg_name)-$($pkg_version)\bin\kitchen"
-
-    # Create a batch wrapper script that sets up the environment using runtime paths
-    $wrapperContent = @"
-@echo off
-setlocal enabledelayedexpansion
-REM Wrapper script for Test Kitchen Enterprise
-REM Sets up Ruby gem environment and executes kitchen
-
-REM Get the package prefix from the script location
-for %%I in ("%~dp0..") do set "PKG_PREFIX=%%~fI"
-
-REM Use hab to find the Ruby installation path
-for /f "delims=" %%i in ('hab pkg path core/ruby3_4-plus-devkit 2^>nul') do set "RUBY_PATH=%%i"
-
-if not defined RUBY_PATH (
-    echo ERROR: Could not find Ruby installation. Run: hab pkg install core/ruby3_4-plus-devkit
-    exit /b 1
-)
-
-REM Set Ruby paths for gem loading - include both vendor and Ruby system gems
-set "GEM_HOME=%PKG_PREFIX%\vendor"
-set "GEM_PATH=%PKG_PREFIX%\vendor;%RUBY_PATH%\lib\ruby\gems\3.4.0"
-
-REM Set encoding to UTF-8 to handle non-ASCII characters
-set "RUBYOPT=-Eutf-8"
-
-REM Execute the real kitchen binary with ruby
-"%RUBY_PATH%\bin\ruby.exe" "%PKG_PREFIX%\$kitchenBinPath" %*
-"@
-
-    # On Windows, only create .bat file for compatibility
-    Set-Content -Path "$WrapperPath.bat" -Value $wrapperContent -Encoding ASCII
-
-    Write-BuildLine "Wrapper created successfully at $WrapperPath.bat"
 }
 
 function Invoke-After {
@@ -206,9 +148,9 @@ function Invoke-After {
     # Remove the byproducts of compiling gems with extensions
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
-    # Remove .github directories from vendored gems to reduce package size and avoid scanner noise
-    Get-ChildItem $pkg_prefix/vendor/gems -Filter ".github" -Directory -Recurse `
-        | Remove-Item -Recurse -Force
+    # Remove vendored .github directories to reduce scanner false positives.
+    Get-ChildItem $pkg_prefix/vendor -Filter ".github" -Directory -Recurse -ErrorAction SilentlyContinue `
+        | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 function Install-ChefOfficialDistribution {

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -131,8 +131,19 @@ function Invoke-Install {
         }
 
         # Ensure appbundler and installed gems resolve from the packaged vendor path.
-        $env:GEM_PATH = "$pkg_prefix/vendor"
+        if ([string]::IsNullOrEmpty($env:GEM_PATH)) {
+            $env:GEM_PATH = "$pkg_prefix/vendor"
+        } else {
+            $env:GEM_PATH = "$pkg_prefix/vendor;$env:GEM_PATH"
+        }
         $env:GEM_HOME = "$pkg_prefix/vendor"
+
+        & gem list -i "^racc$" | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-BuildLine "** Installing racc gem for appbundler lockfile generation"
+            gem install racc --no-document --force --install-dir "$env:GEM_HOME" --ignore-dependencies
+            if ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
+        }
 
         if (-not (Test-Path "$pkg_prefix/bin")) {
             New-Item -ItemType Directory -Path "$pkg_prefix/bin" | Out-Null

--- a/habitat/plan.ps1
+++ b/habitat/plan.ps1
@@ -36,7 +36,6 @@ function Invoke-Build {
         $env:Path += ";c:\\Program Files\\Git\\bin"
         Push-Location $project_root
         $env:GEM_HOME = "$HAB_CACHE_SRC_PATH/$pkg_dirname/vendor"
-        $env:CHEF_TEST_KITCHEN_ENTERPRISE = "true"
 
         Write-BuildLine " ** Enabling Windows long path support"
         # Enable Git long paths for bundler git operations
@@ -130,20 +129,9 @@ function Invoke-Install {
             Copy-Item -Path "$pkg_prefix/Gemfile.lock" -Destination (Join-Path $bundleDir "Gemfile.lock") -Force
         }
 
-        # Ensure appbundler and installed gems resolve from the packaged vendor path.
-        if ([string]::IsNullOrEmpty($env:GEM_PATH)) {
-            $env:GEM_PATH = "$pkg_prefix/vendor"
-        } else {
-            $env:GEM_PATH = "$pkg_prefix/vendor;$env:GEM_PATH"
-        }
+        # Resolve all gems from the packaged vendor path.
+        $env:GEM_PATH = "$pkg_prefix/vendor"
         $env:GEM_HOME = "$pkg_prefix/vendor"
-
-        & gem list -i "^racc$" | Out-Null
-        if ($LASTEXITCODE -ne 0) {
-            Write-BuildLine "** Installing racc gem for appbundler lockfile generation"
-            gem install racc --no-document --force --install-dir "$env:GEM_HOME" --ignore-dependencies
-            if ($LASTEXITCODE -ne 0) { Exit $LASTEXITCODE }
-        }
 
         if (-not (Test-Path "$pkg_prefix/bin")) {
             New-Item -ItemType Directory -Path "$pkg_prefix/bin" | Out-Null
@@ -187,9 +175,6 @@ function Invoke-After {
     # Remove the byproducts of compiling gems with extensions
     Get-ChildItem $pkg_prefix/vendor/gems -Include @("gem_make.out", "mkmf.log", "Makefile") -File -Recurse `
         | Remove-Item -Force
-    # Remove vendored .github directories to reduce scanner false positives.
-    Get-ChildItem $pkg_prefix/vendor -Filter ".github" -Directory -Recurse -ErrorAction SilentlyContinue `
-        | Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
 }
 
 function Install-ChefOfficialDistribution {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -59,7 +59,7 @@ do_build() {
   if [[ ! -f Gemfile.lock ]]; then
     bundle lock
   fi
-  ruby ./cleanup_lint_roller.rb
+  ruby ./cleanup_gem_lockfiles.rb
   ruby ./post-bundle-install.rb
 
   gem build chef-test-kitchen-enterprise.gemspec

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -12,6 +12,7 @@ pkg_bin_dirs=(
 pkg_build_deps=(
   core/make
   core/bash
+  core/sed
   core/gcc
   core/git
 )
@@ -82,43 +83,18 @@ do_install() {
 
   make_pkg_official_distrib
 
-  wrap_ruby_kitchen
+  build_line "Generating appbundler binstubs with precise version pins"
+  "$(pkg_path_for $_ruby_pkg)/bin/ruby" "$pkg_prefix/vendor/bin/appbundler" "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
+
+  build_line "Patching generated binstubs for Habitat runtime env"
+  for binstub in "$pkg_prefix"/bin/*; do
+    if [[ -f "$binstub" ]]; then
+      sed -i "/require \"rubygems\"/r $PLAN_CONTEXT/binstub_patch.rb" "$binstub"
+    fi
+  done
+
   set_runtime_env "GEM_PATH" "${pkg_prefix}/vendor"
-}
-
-wrap_ruby_kitchen() {
-  local bin="$pkg_prefix/bin/kitchen"
-  local real_bin="$GEM_HOME/gems/chef-test-kitchen-enterprise-$(pkg_version)/bin/kitchen"
-  wrap_bin_with_ruby "$bin" "$real_bin"
-}
-
-wrap_bin_with_ruby() {
-  local bin="$1"
-  local real_bin="$2"
-  local ruby_default_gem_dir
-
-  # Include the packaged Ruby's default gem directory in GEM_PATH.
-  ruby_default_gem_dir="$(env -u GEM_HOME -u GEM_PATH "$(pkg_path_for $_ruby_pkg)/bin/ruby" -rrubygems -e 'puts Gem.default_dir')"
-  build_line "Detected Ruby default gem dir: ${ruby_default_gem_dir}"
-
-  build_line "Adding wrapper $bin to $real_bin"
-  cat <<EOF > "$bin"
-#!$(pkg_path_for core/bash)/bin/bash
-set -e
-
-# Set binary path that allows chef-test-kitchen-enterprise to use non-Hab pkg binaries
-export PATH="/sbin:/usr/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:\$PATH"
-
-# Set Ruby paths defined from 'do_setup_environment()'
-export GEM_HOME="$pkg_prefix/vendor"
-export GEM_PATH="\$GEM_HOME:${ruby_default_gem_dir}"
-
-# Set encoding to UTF-8 to handle non-ASCII characters in gem files
-export RUBYOPT="-Eutf-8"
-
-exec $(pkg_path_for $_ruby_pkg)/bin/ruby $real_bin \$@
-EOF
-  chmod -v 755 "$bin"
+  set_runtime_env "APPBUNDLER_ALLOW_RVM" "true"
 }
 
 make_pkg_official_distrib() {
@@ -130,8 +106,8 @@ make_pkg_official_distrib() {
 }
 
 do_after() {
-  # Remove .github directories from vendored gems to reduce package size and avoid scanner noise
-  find "$pkg_prefix/vendor/gems" -name ".github" -type d -exec rm -rf {} + 2>/dev/null || true
+  build_line "Removing .github directories from vendored gems"
+  find "$pkg_prefix/vendor" -type d -name ".github" -exec rm -rf {} + 2>/dev/null || true
 }
 
 do_strip() {

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -55,7 +55,12 @@ do_build() {
   bundle config --local silence_root_warning 1
 
   bundle install
-  ruby ./cleanup_gem_lockfiles.rb
+  # appbundler requires Gemfile.lock in BUNDLE_DIR. Generate it only when missing
+  # so this stays aligned with chef pattern if a lockfile is later committed.
+  if [[ ! -f Gemfile.lock ]]; then
+    bundle lock
+  fi
+  ruby ./cleanup_lint_roller.rb
   ruby ./post-bundle-install.rb
 
   gem build chef-test-kitchen-enterprise.gemspec

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -88,6 +88,12 @@ do_install() {
 
   make_pkg_official_distrib
 
+  # appbundler requires Gemfile.lock in the same BUNDLE_DIR we pass below.
+  if [[ ! -f "$HAB_CACHE_SRC_PATH/$pkg_dirname/Gemfile.lock" ]]; then
+    build_line "Gemfile.lock missing in $HAB_CACHE_SRC_PATH/$pkg_dirname; generating it now"
+    (cd "$HAB_CACHE_SRC_PATH/$pkg_dirname" && bundle lock)
+  fi
+
   build_line "Generating appbundler binstubs with precise version pins"
   "$(pkg_path_for $_ruby_pkg)/bin/ruby" "$pkg_prefix/vendor/bin/appbundler" "$HAB_CACHE_SRC_PATH/$pkg_dirname" "$pkg_prefix/bin" "chef-test-kitchen-enterprise"
 

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -12,7 +12,6 @@ pkg_bin_dirs=(
 pkg_build_deps=(
   core/make
   core/bash
-  core/sed
   core/gcc
   core/git
 )


### PR DESCRIPTION
This pull request introduces several improvements to the packaging and build process for the `chef-test-kitchen-enterprise` Habitat package, focusing on more robust binstub generation, environment setup, and dependency management. The changes modernize how Ruby executables are wrapped and ensure correct environment variables for both Windows and Linux. Additionally, Gemfile and Gemfile.lock handling is now more precise, and unnecessary code is removed to streamline the build scripts.

**Packaging and binstub generation improvements:**

* Replaces custom Ruby binary wrapper scripts with generation and patching of binstubs using `appbundler`, ensuring the correct environment is set for both Linux (`binstub_patch.rb`) and Windows (`binstub_patch.bat`). This allows for more reliable execution of Ruby binaries and better compatibility with the Habitat runtime. [[1]](diffhunk://#diff-9369dcde2f89abf07f786471eddf21551e7056466860f59b01c996e2aacf3df1L94-R157) [[2]](diffhunk://#diff-5901a181ccb1fa37ee65d1dcacf22edee3996d0360fdcf54dd1b4265ceaacfaaL85-R107) [[3]](diffhunk://#diff-d67f041f21bd9cb77bffee0be748dc8cfbf6560f6c40f6b18c842b6fb23d5c4fR1-R15) [[4]](diffhunk://#diff-d3de738048692fe7789b4bad9878afab4e897c520d4d5b0906b5360da02281f9R1-R4)
* Adds the `appbundler` gem as a packaging dependency in the `Gemfile`, and ensures it is used for binstub generation.

**Dependency and environment management:**

* Improves Gemfile and Gemfile.lock selection logic to always use the project's lockfile and ensure the correct files are present in the package, avoiding accidental use of vendored or incorrect lockfiles. [[1]](diffhunk://#diff-9369dcde2f89abf07f786471eddf21551e7056466860f59b01c996e2aacf3df1L94-R157) [[2]](diffhunk://#diff-5901a181ccb1fa37ee65d1dcacf22edee3996d0360fdcf54dd1b4265ceaacfaaR57-R61)
* Sets up the correct `GEM_PATH` to include both the package's vendor directory and Ruby's default gem directory, ensuring all required gems (including Ruby stdlib gems) are available at runtime. [[1]](diffhunk://#diff-9369dcde2f89abf07f786471eddf21551e7056466860f59b01c996e2aacf3df1L94-R157) [[2]](diffhunk://#diff-d3de738048692fe7789b4bad9878afab4e897c520d4d5b0906b5360da02281f9R1-R4)

**Build and test script simplification:**

* Removes the custom `Wrap-KitchenBinary` and related wrapper generation logic from the Windows build script, replacing it with the new binstub patching approach.
* Updates the Gemfile to only reference the `test-kitchen` gemspec if it exists, preventing errors during packaging.

**Cleanup and maintenance:**

* Moves the removal of `.github` directories from vendored gems to a more appropriate location and ensures it covers all vendored gems, not just those in the `gems` subdirectory. [[1]](diffhunk://#diff-5901a181ccb1fa37ee65d1dcacf22edee3996d0360fdcf54dd1b4265ceaacfaaL133-R120) [[2]](diffhunk://#diff-9369dcde2f89abf07f786471eddf21551e7056466860f59b01c996e2aacf3df1L209-L211)

**Other minor improvements:**

* Simplifies and improves the Habitat installation process in test scripts, and removes unnecessary debug output. [[1]](diffhunk://#diff-ed5d080ecf41ee08c4d50b0c9d4fae51157b6b4b743dcb69b38250e50e498552L12) [[2]](diffhunk://#diff-ed5d080ecf41ee08c4d50b0c9d4fae51157b6b4b743dcb69b38250e50e498552L31-R31) [[3]](diffhunk://#diff-ed5d080ecf41ee08c4d50b0c9d4fae51157b6b4b743dcb69b38250e50e498552L67-R54) [[4]](diffhunk://#diff-ed5d080ecf41ee08c4d50b0c9d4fae51157b6b4b743dcb69b38250e50e498552L84-L86)

These changes collectively make the build and packaging process more robust, maintainable, and compatible with Habitat and Ruby best practices.