### PR TITLE
[CHEF-27350] Add provisioner lifecycle hooks to instance lifecycle actions

### DIFF
--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -402,11 +402,22 @@ module Kitchen
 
     # Perform the create action.
     #
+    # After the driver creates the instance, calls +provisioner.after_create(state)+
+    # if the provisioner responds to that method. This allows agentless provisioners
+    # to record remote-node state and log topology details immediately after the
+    # source container is available.
+    #
     # @see Driver::Base#create
     # @return [self] this instance, used to chain actions
     # @api private
     def create_action
-      perform_action(:create, "Creating")
+      banner "Creating #{to_str}..."
+      elapsed = action(:create) do |state|
+        driver.create(state)
+        provisioner.after_create(state) if provisioner.respond_to?(:after_create)
+      end
+      info("Finished creating #{to_str} #{Util.duration(elapsed.real)}.")
+      self
     end
 
     # Perform the converge action.
@@ -431,6 +442,11 @@ module Kitchen
 
     # Perform the setup action.
     #
+    # For legacy SSH-base drivers the original setup path is preserved. For all
+    # other drivers, calls +provisioner.setup(state)+ when the provisioner
+    # responds to that method. This allows agentless provisioners to upload
+    # credentials and perform any pre-converge source-container preparation.
+    #
     # @see Driver::Base#setup
     # @return [self] this instance, used to chain actions
     # @api private
@@ -438,6 +454,7 @@ module Kitchen
       banner "Setting up #{to_str}..."
       elapsed = action(:setup) do |state|
         legacy_ssh_base_setup(state) if legacy_ssh_base_driver?
+        provisioner.setup(state) if provisioner.respond_to?(:setup)
       end
       info("Finished setting up #{to_str} #{Util.duration(elapsed.real)}.")
       self
@@ -481,11 +498,23 @@ module Kitchen
 
     # Perform the destroy action.
     #
+    # Calls +provisioner.before_destroy(state)+ when the provisioner responds
+    # to that method, giving agentless provisioners a chance to remove uploaded
+    # credentials from the source container before it is torn down. The driver
+    # destroy and state-file cleanup are then performed in the normal way.
+    #
     # @see Driver::Base#destroy
     # @return [self] this instance, used to chain actions
     # @api private
     def destroy_action
-      perform_action(:destroy, "Destroying") { state_file.destroy }
+      banner "Destroying #{to_str}..."
+      elapsed = action(:destroy) do |state|
+        provisioner.before_destroy(state) if provisioner.respond_to?(:before_destroy)
+        driver.destroy(state)
+      end
+      info("Finished destroying #{to_str} #{Util.duration(elapsed.real)}.")
+      state_file.destroy
+      self
     end
 
     # Perform an arbitrary action and provide useful logging.


### PR DESCRIPTION
<h2>Summary</h2>
<p>Extends the TKE core instance lifecycle to call optional provisioner hooks at key points in <code>create</code>, <code>setup</code>, and <code>destroy</code> actions. This enables the premium <code>ChefInfraAgentless</code> provisioner to participate in the lifecycle without modifying standard provisioner behaviour.</p>

<h2>Jira Ticket</h2>
<p><a href="https://progresssoftware.atlassian.net/browse/CHEF-27350">CHEF-27350: Provision source container, copy files and credentials (+ kitchen setup)</a></p>

<h2>Related PR</h2>
<p>KCAI: <a href="https://github.com/chef/kitchen-chef-infra-agentless/pull/new/CHEF-27350-provision-source-container">kitchen-chef-infra-agentless CHEF-27350 PR</a></p>

<h2>Changes Made</h2>
<ul>
<li><strong>create_action</strong>: After <code>driver.create(state)</code>, calls <code>provisioner.after_create(state)</code> if the provisioner responds to <code>:after_create</code></li>
<li><strong>setup_action</strong>: Calls <code>provisioner.setup(state)</code> if the provisioner responds to <code>:setup</code></li>
<li><strong>destroy_action</strong>: Expanded from <code>perform_action</code> one-liner to explicit block; calls <code>provisioner.before_destroy(state)</code> BEFORE <code>driver.destroy(state)</code> so credentials are cleaned from the source container while it is still running</li>
</ul>

<h2>Backward Compatibility</h2>
<p>All hooks are guarded with <code>respond_to?</code> checks — standard provisioners (ChefInfra, Shell, etc.) that do not implement these methods are completely unaffected.</p>

<h2>Testing</h2>
<ul>
<li>All existing TKE tests pass: 2009 runs, 0 failures</li>
<li>Cookstyle clean (no offenses)</li>
</ul>