### PR TITLE
[CHEF-34937] Improve empty remote_nodes error to mention ERB templating

### DIFF
--- a/lib/kitchen/agentless/context.rb
+++ b/lib/kitchen/agentless/context.rb
@@ -104,7 +104,10 @@ module Kitchen
         return unless remote_nodes.empty?
 
         raise Kitchen::UserError,
-          "agentless.remote_nodes must contain at least one node"
+          "agentless.remote_nodes must contain at least one node. " \
+          "If you are using ERB templating to generate the node list, verify that " \
+          "your ERB expression evaluates to a non-empty Array or Hash at runtime " \
+          "(e.g., check that required environment variables or files are present)."
       end
     end
   end

--- a/spec/kitchen/agentless/context_spec.rb
+++ b/spec/kitchen/agentless/context_spec.rb
@@ -152,12 +152,20 @@ describe Kitchen::Agentless::Context do
     it "raises UserError when remote_nodes is empty" do
       config = { "remote_nodes" => [] }
       ctx = Kitchen::Agentless::Context.new(config)
-      _(proc { ctx.validate! }).must_raise Kitchen::UserError
+      err = _(proc { ctx.validate! }).must_raise Kitchen::UserError
+      _(err.message).must_match(/remote_nodes must contain at least one node/)
     end
 
     it "raises UserError when remote_nodes is absent" do
       ctx = Kitchen::Agentless::Context.new({})
       _(proc { ctx.validate! }).must_raise Kitchen::UserError
+    end
+
+    it "mentions ERB templating in the empty remote_nodes error message" do
+      config = { "remote_nodes" => [] }
+      ctx = Kitchen::Agentless::Context.new(config)
+      err = _(proc { ctx.validate! }).must_raise Kitchen::UserError
+      _(err.message).must_match(/ERB/)
     end
 
     it "propagates UserError from invalid RemoteNode" do


### PR DESCRIPTION
<h2>Summary</h2>
<p>TKE core companion to <a href="https://github.com/chef/kitchen-chef-infra-agentless/pull/13">kitchen-chef-infra-agentless PR #13</a> for CHEF-34937.</p>
<p>When <code>agentless.remote_nodes</code> is empty (for example because an ERB expression evaluated to an empty list), the <code>UserError</code> message now explicitly mentions ERB templating and advises the user to check environment variables or node list files.</p>

<h2>Jira Ticket</h2>
<p><a href="https://progresssoftware.atlassian.net/browse/CHEF-34937">CHEF-34937: Support dynamic target node lists via ERB templating in kitchen.yml</a></p>

<h2>Changes Made</h2>
<ul>
<li><code>lib/kitchen/agentless/context.rb</code> — improved <code>validate_remote_nodes_present!</code> error message to mention ERB templating as a possible cause of an empty node list</li>
<li><code>spec/kitchen/agentless/context_spec.rb</code> — added dedicated test asserting the ERB mention in the error message; updated existing test to assert on message content</li>
</ul>

<h2>Testing Performed</h2>
<ul>
<li>22 context spec tests — all passing</li>
<li>Cookstyle clean</li>
</ul>

<h2>Files Modified</h2>
<ul>
<li><code>lib/kitchen/agentless/context.rb</code></li>
<li><code>spec/kitchen/agentless/context_spec.rb</code></li>
</ul>