### PR TITLE
[CHEF-34939] Add transport field to RemoteNode for WinRM/Windows support

### DIFF
--- a/lib/kitchen/agentless/remote_node.rb
+++ b/lib/kitchen/agentless/remote_node.rb
@@ -30,10 +30,15 @@ module Kitchen
     class RemoteNode
       VALID_MODES = %w{container real}.freeze
       VALID_CREDENTIAL_PASSING_MODES = %w{pass-by-env-var pass-cmd-line pass-by-creds-file}.freeze
+      VALID_TRANSPORTS = %w{ssh winrm}.freeze
+
+      # Default ports for each transport protocol (used for validation hints).
+      WINRM_DEFAULT_PORT = 5985
+      SSH_DEFAULT_PORT   = 22
 
       attr_reader :name, :mode, :image, :fqdn, :endpoint,
         :credential_map_file, :credential_passing_mode,
-        :compliance_mode_cred_file
+        :compliance_mode_cred_file, :transport
 
       # @param config [Hash] a single entry from the remote_nodes Array
       # @raise [Kitchen::UserError] if required fields are missing or invalid
@@ -46,6 +51,7 @@ module Kitchen
         @credential_map_file     = config["credential-map-file"] || config[:"credential-map-file"]
         @credential_passing_mode = config["credential-passing-mode"] || config[:"credential-passing-mode"]
         @compliance_mode_cred_file = config["compliance-mode-cred-file"] || config[:"compliance-mode-cred-file"]
+        @transport = (config["transport"] || config[:transport])&.to_s
       end
 
       # @return [Boolean] true if this node is managed as a Docker container
@@ -58,6 +64,18 @@ module Kitchen
         mode == "real"
       end
 
+      # @return [Boolean] true if the transport for this node is WinRM.
+      # When `transport` is not explicitly set, the transport is determined
+      # by the credentials file; this returns false in that case.
+      def winrm?
+        transport == "winrm"
+      end
+
+      # @return [Boolean] true if the transport for this node is SSH (or unset).
+      def ssh?
+        transport.nil? || transport == "ssh"
+      end
+
       # Validates that all required fields are present and values are legal.
       #
       # @raise [Kitchen::UserError] with a descriptive message on failure
@@ -65,12 +83,22 @@ module Kitchen
         raise Kitchen::UserError, "Remote node is missing required field 'name'" if name.nil? || name.empty?
 
         validate_mode!
+        validate_transport!
         validate_container_fields! if container_mode?
         validate_real_fields! if real_mode?
         validate_credential_fields!
       end
 
       private
+
+      def validate_transport!
+        return if transport.nil?
+        return if VALID_TRANSPORTS.include?(transport)
+
+        raise Kitchen::UserError,
+          "Remote node '#{name}' has invalid transport '#{transport}'. " \
+          "Valid values: #{VALID_TRANSPORTS.join(", ")}"
+      end
 
       def validate_mode!
         return if VALID_MODES.include?(mode)

--- a/spec/kitchen/agentless/remote_node_spec.rb
+++ b/spec/kitchen/agentless/remote_node_spec.rb
@@ -195,5 +195,69 @@ describe Kitchen::Agentless::RemoteNode do
         _(proc { node.validate! }).must_be_silent
       end
     end
+
+    describe "WinRM transport support" do
+      let(:winrm_real_config) do
+        {
+          "name" => "win-server-1",
+          "test-kitchen-mode" => "real",
+          "transport" => "winrm",
+          "endpoint" => "10.0.0.5:5985",
+          "credential-map-file" => "test/creds.yml",
+          "credential-passing-mode" => "pass-by-creds-file",
+        }
+      end
+
+      it "accepts transport: winrm" do
+        node = Kitchen::Agentless::RemoteNode.new(winrm_real_config)
+        _(node.transport).must_equal "winrm"
+        _(proc { node.validate! }).must_be_silent
+      end
+
+      it "winrm? returns true for transport: winrm" do
+        node = Kitchen::Agentless::RemoteNode.new(winrm_real_config)
+        _(node.winrm?).must_equal true
+        _(node.ssh?).must_equal false
+      end
+
+      it "accepts transport: ssh explicitly" do
+        config = winrm_real_config.merge("transport" => "ssh", "endpoint" => "10.0.0.5:22")
+        node = Kitchen::Agentless::RemoteNode.new(config)
+        _(node.transport).must_equal "ssh"
+        _(node.ssh?).must_equal true
+        _(node.winrm?).must_equal false
+      end
+
+      it "ssh? returns true when transport is not set" do
+        config = winrm_real_config.reject { |k, _| k == "transport" }
+        node = Kitchen::Agentless::RemoteNode.new(config)
+        _(node.transport).must_be_nil
+        _(node.ssh?).must_equal true
+        _(node.winrm?).must_equal false
+      end
+
+      it "raises UserError for an invalid transport value" do
+        config = winrm_real_config.merge("transport" => "rdp")
+        node = Kitchen::Agentless::RemoteNode.new(config)
+        err = _(proc { node.validate! }).must_raise Kitchen::UserError
+        _(err.message).must_include "rdp"
+        _(err.message).must_include "ssh"
+        _(err.message).must_include "winrm"
+      end
+
+      it "accepts WinRM container-mode node" do
+        config = {
+          "name" => "win-ctr",
+          "test-kitchen-mode" => "container",
+          "transport" => "winrm",
+          "test-kitchen-image" => "mcr.microsoft.com/windows/servercore:ltsc2022",
+          "credential-map-file" => "test/creds.yml",
+          "credential-passing-mode" => "pass-by-creds-file",
+        }
+        node = Kitchen::Agentless::RemoteNode.new(config)
+        _(node.winrm?).must_equal true
+        _(proc { node.validate! }).must_be_silent
+      end
+    end
   end
 end


### PR DESCRIPTION
<h2>Summary</h2>
<p>Adds a <code>transport</code> attribute to <code>Kitchen::Agentless::RemoteNode</code> so users can declare the transport protocol (ssh or winrm) directly in <code>kitchen.yml</code> rather than only in credentials.yml. This is the TKE core change for CHEF-34939.</p>

<h2>Jira Ticket</h2>
<p><a href="https://progresssoftware.atlassian.net/browse/CHEF-34939">CHEF-34939: Support WinRM transport and Windows targets in TKE Agentless Mode</a></p>

<h2>Changes Made</h2>
<ul>
<li>Added <code>:transport</code> attr_reader to <code>RemoteNode</code> (optional, defaults to nil = SSH)</li>
<li>Added <code>VALID_TRANSPORTS</code>, <code>SSH_DEFAULT_PORT</code>, <code>WINRM_DEFAULT_PORT</code> constants</li>
<li>Added <code>winrm?</code> and <code>ssh?</code> helper predicates</li>
<li>7 new unit tests covering transport defaults, helpers, and validation</li>
</ul>

<h2>Related PR</h2>
<p>KCAI companion PR: https://github.com/chef/kitchen-chef-infra-agentless/pull/14</p>