### PR TITLE
[CHEF-23408] Wave 8: kitchen list shows remote node status

### DIFF
--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #
-# Copyright (C) 2013, Fletcher Nichol
+# Copyright:: (C) 2013, Fletcher Nichol
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative "../command"
-require "json" unless defined?(JSON)
+require_relative '../command'
+require 'json' unless defined?(JSON)
 
 module Kitchen
   module Command
@@ -28,7 +28,7 @@ module Kitchen
       def call
         result = parse_subcommand(args.first)
         if options[:debug]
-          die "The --debug flag on the list subcommand is deprecated, " \
+          die 'The --debug flag on the list subcommand is deprecated, ' \
             "please use `kitchen diagnose'."
         elsif options[:bare]
           puts Array(result).map(&:name).join("\n")
@@ -36,6 +36,7 @@ module Kitchen
           puts JSON.pretty_generate(Array(result).map { |r| to_hash(r) })
         else
           list_table(result)
+          list_remote_nodes(result)
         end
       end
 
@@ -48,7 +49,7 @@ module Kitchen
       # @return [String]
       # @api private
       def color_pad(string)
-        string + colorize("", :white)
+        string + colorize('', :white)
       end
 
       # Generate the display rows for an instance.
@@ -75,12 +76,12 @@ module Kitchen
       # @api private
       def format_last_action(last_action)
         case last_action
-        when "create" then colorize("Created", :cyan)
-        when "converge" then colorize("Converged", :magenta)
-        when "setup" then colorize("Set Up", :blue)
-        when "verify" then colorize("Verified", :yellow)
-        when nil then colorize("<Not Created>", :red)
-        else colorize("<Unknown>", :white)
+        when 'create' then colorize('Created', :cyan)
+        when 'converge' then colorize('Converged', :magenta)
+        when 'setup' then colorize('Set Up', :blue)
+        when 'verify' then colorize('Verified', :yellow)
+        when nil then colorize('<Not Created>', :red)
+        else colorize('<Unknown>', :white)
         end
       end
 
@@ -91,7 +92,7 @@ module Kitchen
       # @api private
       def format_last_error(last_error)
         case last_error
-        when nil then colorize("<None>", :white)
+        when nil then colorize('<None>', :white)
         else colorize(last_error, :red)
         end
       end
@@ -103,10 +104,10 @@ module Kitchen
       def list_table(result)
         table = [
           [
-            colorize("Instance", :green), colorize("Driver", :green),
-            colorize("Provisioner", :green), colorize("Verifier", :green),
-            colorize("Transport", :green), colorize("Last Action", :green),
-            colorize("Last Error", :green)
+            colorize('Instance', :green), colorize('Driver', :green),
+            colorize('Provisioner', :green), colorize('Verifier', :green),
+            colorize('Transport', :green), colorize('Last Action', :green),
+            colorize('Last Error', :green)
           ],
         ]
         table += Array(result).map { |i| display_instance(i) }
@@ -118,7 +119,7 @@ module Kitchen
       # @param result [Hash{Symbol => String}] hash of a single instance
       # @api private
       def to_hash(result)
-        {
+        h = {
           instance: result.name,
           driver: result.driver.name,
           provisioner: result.provisioner.name,
@@ -127,6 +128,70 @@ module Kitchen
           last_action: result.last_action,
           last_error: result.last_error,
         }
+        if result.provisioner.respond_to?(:agentless_node_status)
+          h[:remote_nodes] = result.provisioner.agentless_node_status
+        end
+        h
+      end
+
+      # Prints a "Remote Nodes" sub-table for each instance whose provisioner
+      # supports {#agentless_node_status}.  Called after the main instance table.
+      #
+      # Outputs nothing if no instance is running in agentless mode or if all
+      # provisioners return an empty node list.
+      #
+      # @param result [Array<Instance>] array of instances from parse_subcommand
+      # @api private
+      def list_remote_nodes(result)
+        agentless_instances = Array(result).select do |i|
+          i.provisioner.respond_to?(:agentless_node_status)
+        end
+        return if agentless_instances.empty?
+
+        agentless_instances.each do |instance|
+          nodes = instance.provisioner.agentless_node_status
+          next if nodes.nil? || nodes.empty?
+
+          puts ''
+          puts colorize("Remote Nodes: #{instance.name}", :green)
+
+          table = [[
+            colorize('Node', :green),
+            colorize('Mode', :green),
+            colorize('Endpoint', :green),
+            colorize('Credentials', :green),
+            colorize('Status', :green),
+            colorize('Last Converge', :green),
+          ]]
+
+          nodes.each do |n|
+            table << [
+              color_pad(n[:name].to_s),
+              color_pad(n[:mode].to_s),
+              color_pad(n[:endpoint].to_s),
+              color_pad(n[:credentials_provisioned] ? 'Provisioned' : '<None>'),
+              format_node_status(n[:status].to_s),
+              color_pad(n[:last_converge].to_s),
+            ]
+          end
+
+          print_table(table)
+        end
+      end
+
+      # Format and color a remote node status string.
+      #
+      # @param status [String]
+      # @return [String]
+      # @api private
+      def format_node_status(status)
+        case status
+        when 'Converged'     then colorize('Converged', :magenta)
+        when 'Set Up'        then colorize('Set Up', :blue)
+        when 'Created'       then colorize('Created', :cyan)
+        when '<Not Created>' then colorize('<Not Created>', :red)
+        else colorize(status, :white)
+        end
       end
 
       # Outputs a formatted display table.

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../command'
-require 'json' unless defined?(JSON)
+require_relative "../command"
+require "json" unless defined?(JSON)
 
 module Kitchen
   module Command
@@ -28,7 +28,7 @@ module Kitchen
       def call
         result = parse_subcommand(args.first)
         if options[:debug]
-          die 'The --debug flag on the list subcommand is deprecated, ' \
+          die "The --debug flag on the list subcommand is deprecated, " \
             "please use `kitchen diagnose'."
         elsif options[:bare]
           puts Array(result).map(&:name).join("\n")
@@ -49,7 +49,7 @@ module Kitchen
       # @return [String]
       # @api private
       def color_pad(string)
-        string + colorize('', :white)
+        string + colorize("", :white)
       end
 
       # Generate the display rows for an instance.
@@ -76,12 +76,12 @@ module Kitchen
       # @api private
       def format_last_action(last_action)
         case last_action
-        when 'create' then colorize('Created', :cyan)
-        when 'converge' then colorize('Converged', :magenta)
-        when 'setup' then colorize('Set Up', :blue)
-        when 'verify' then colorize('Verified', :yellow)
-        when nil then colorize('<Not Created>', :red)
-        else colorize('<Unknown>', :white)
+        when "create" then colorize("Created", :cyan)
+        when "converge" then colorize("Converged", :magenta)
+        when "setup" then colorize("Set Up", :blue)
+        when "verify" then colorize("Verified", :yellow)
+        when nil then colorize("<Not Created>", :red)
+        else colorize("<Unknown>", :white)
         end
       end
 
@@ -92,7 +92,7 @@ module Kitchen
       # @api private
       def format_last_error(last_error)
         case last_error
-        when nil then colorize('<None>', :white)
+        when nil then colorize("<None>", :white)
         else colorize(last_error, :red)
         end
       end
@@ -104,10 +104,10 @@ module Kitchen
       def list_table(result)
         table = [
           [
-            colorize('Instance', :green), colorize('Driver', :green),
-            colorize('Provisioner', :green), colorize('Verifier', :green),
-            colorize('Transport', :green), colorize('Last Action', :green),
-            colorize('Last Error', :green)
+            colorize("Instance", :green), colorize("Driver", :green),
+            colorize("Provisioner", :green), colorize("Verifier", :green),
+            colorize("Transport", :green), colorize("Last Action", :green),
+            colorize("Last Error", :green)
           ],
         ]
         table += Array(result).map { |i| display_instance(i) }
@@ -152,16 +152,16 @@ module Kitchen
           nodes = instance.provisioner.agentless_node_status
           next if nodes.nil? || nodes.empty?
 
-          puts ''
+          puts ""
           puts colorize("Remote Nodes: #{instance.name}", :green)
 
           table = [[
-            colorize('Node', :green),
-            colorize('Mode', :green),
-            colorize('Endpoint', :green),
-            colorize('Credentials', :green),
-            colorize('Status', :green),
-            colorize('Last Converge', :green),
+            colorize("Node", :green),
+            colorize("Mode", :green),
+            colorize("Endpoint", :green),
+            colorize("Credentials", :green),
+            colorize("Status", :green),
+            colorize("Last Converge", :green),
           ]]
 
           nodes.each do |n|
@@ -169,7 +169,7 @@ module Kitchen
               color_pad(n[:name].to_s),
               color_pad(n[:mode].to_s),
               color_pad(n[:endpoint].to_s),
-              color_pad(n[:credentials_provisioned] ? 'Provisioned' : '<None>'),
+              color_pad(n[:credentials_provisioned] ? "Provisioned" : "<None>"),
               format_node_status(n[:status].to_s),
               color_pad(n[:last_converge].to_s),
             ]
@@ -186,10 +186,10 @@ module Kitchen
       # @api private
       def format_node_status(status)
         case status
-        when 'Converged'     then colorize('Converged', :magenta)
-        when 'Set Up'        then colorize('Set Up', :blue)
-        when 'Created'       then colorize('Created', :cyan)
-        when '<Not Created>' then colorize('<Not Created>', :red)
+        when "Converged"     then colorize("Converged", :magenta)
+        when "Set Up"        then colorize("Set Up", :blue)
+        when "Created"       then colorize("Created", :cyan)
+        when "<Not Created>" then colorize("<Not Created>", :red)
         else colorize(status, :white)
         end
       end

--- a/spec/kitchen/command/list_spec.rb
+++ b/spec/kitchen/command/list_spec.rb
@@ -1,0 +1,291 @@
+#
+# Author:: Test Kitchen Contributors
+#
+# Copyright:: (C) 2024, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative '../../spec_helper'
+require 'kitchen'
+require 'kitchen/logging'
+require 'kitchen/command/list'
+
+module Kitchen
+  module Command
+    # A real shell object that captures print_table calls and returns
+    # the first argument as-is from set_color (no ANSI codes in tests).
+    class TestShell
+      attr_reader :table_calls, :put_lines
+
+      def initialize
+        @table_calls = []
+        @put_lines   = []
+      end
+
+      def print_table(rows, *_opts)
+        @table_calls << rows
+      end
+
+      # set_color returns the string unchanged so color_pad works correctly.
+      def set_color(str, *_color)
+        str.to_s
+      end
+    end
+
+    describe List do
+      # ---------------------------------------------------------------------------
+      # Helpers
+      # ---------------------------------------------------------------------------
+
+      # Stub a provisioner that does NOT have agentless_node_status (standard).
+      def stub_standard_provisioner(name = 'ChefInfra')
+        p = stub
+        p.stubs(:name).returns(name)
+        p.stubs(:respond_to?).with(:agentless_node_status).returns(false)
+        p
+      end
+
+      # Stub an agentless provisioner with the given node list.
+      def stub_agentless_provisioner(nodes, name = 'ChefInfraAgentless')
+        p = stub
+        p.stubs(:name).returns(name)
+        p.stubs(:respond_to?).with(:agentless_node_status).returns(true)
+        p.stubs(:agentless_node_status).returns(nodes)
+        p
+      end
+
+      # Stub a minimal instance.
+      def stub_instance(name, provisioner, last_action: nil, last_error: nil)
+        i = stub
+        d = stub(name: 'dokken')
+        v = stub(name: 'inspec')
+        t = stub(name: 'dokken')
+        i.stubs(:name).returns(name)
+        i.stubs(:driver).returns(d)
+        i.stubs(:provisioner).returns(provisioner)
+        i.stubs(:verifier).returns(v)
+        i.stubs(:transport).returns(t)
+        i.stubs(:last_action).returns(last_action)
+        i.stubs(:last_error).returns(last_error)
+        i
+      end
+
+      # Build a List command with a real TestShell that captures all output.
+      # Returns [cmd, shell] so callers can inspect shell.table_calls.
+      def build_list_cmd(instances, json: false, bare: false)
+        shell = TestShell.new
+
+        cmd = List.allocate
+        cmd.instance_variable_set(:@args, ['all'])
+        cmd.instance_variable_set(:@options, { json: json, bare: bare, debug: false })
+        cmd.instance_variable_set(:@shell, shell)
+
+        # Stub parse_subcommand to return our test instances
+        cmd.stubs(:parse_subcommand).returns(instances)
+        [cmd, shell]
+      end
+
+      # ---------------------------------------------------------------------------
+      # #list_remote_nodes — display path
+      # ---------------------------------------------------------------------------
+
+      describe '#list_remote_nodes' do
+        it 'outputs nothing when no instances use an agentless provisioner' do
+          prov = stub_standard_provisioner
+          instances = [stub_instance('default-ubuntu-2404', prov)]
+          cmd, shell = build_list_cmd(instances)
+          cmd.send(:list_remote_nodes, instances)
+          _(shell.table_calls).must_be_empty
+        end
+
+        it 'outputs nothing when the agentless provisioner returns an empty array' do
+          prov = stub_agentless_provisioner([])
+          instances = [stub_instance('default-ubuntu-2404', prov)]
+          cmd, shell = build_list_cmd(instances)
+          cmd.send(:list_remote_nodes, instances)
+          _(shell.table_calls).must_be_empty
+        end
+
+        it 'calls print_table once for an agentless instance with nodes' do
+          nodes = [
+            {
+              name: 'edge1', mode: 'container', endpoint: '172.17.0.3:22',
+              credentials_provisioned: true, last_converge: '-', status: 'Set Up'
+            },
+          ]
+          prov = stub_agentless_provisioner(nodes)
+          instance = stub_instance('default-ubuntu-2404', prov)
+          cmd, shell = build_list_cmd([instance])
+          cmd.send(:list_remote_nodes, [instance])
+          # One print_table call for the one agentless instance
+          _(shell.table_calls.size).must_equal 1
+        end
+
+        it 'prints a table with one data row per remote node (plus a header row)' do
+          nodes = [
+            {
+              name: 'node-a', mode: 'real', endpoint: '10.0.0.1:22',
+              credentials_provisioned: false, last_converge: '-', status: 'Created'
+            },
+            {
+              name: 'node-b', mode: 'container', endpoint: '172.17.0.4:22',
+              credentials_provisioned: true, last_converge: '2026-01-01T00:00:00Z', status: 'Converged'
+            },
+          ]
+          prov = stub_agentless_provisioner(nodes)
+          instance = stub_instance('default-ubuntu-2404', prov)
+          cmd, shell = build_list_cmd([instance])
+          cmd.send(:list_remote_nodes, [instance])
+
+          # 1 header row + 2 data rows
+          rows = shell.table_calls.first
+          _(rows.size).must_equal 3
+          # Node names appear in data rows
+          data_rows = rows.drop(1)
+          _(data_rows.any? { |r| r.first.to_s.include?('node-a') }).must_equal true
+          _(data_rows.any? { |r| r.first.to_s.include?('node-b') }).must_equal true
+        end
+
+        it "shows 'Provisioned' in the credentials column when credentials_provisioned is true" do
+          nodes = [
+            {
+              name: 'n1', mode: 'real', endpoint: '10.0.0.1:22',
+              credentials_provisioned: true, last_converge: '-', status: 'Set Up'
+            },
+          ]
+          prov = stub_agentless_provisioner(nodes)
+          instance = stub_instance('default-ubuntu-2404', prov)
+          cmd, shell = build_list_cmd([instance])
+          cmd.send(:list_remote_nodes, [instance])
+
+          data_row = shell.table_calls.first[1] # first data row (after header)
+          _(data_row.any? { |c| c.to_s.include?('Provisioned') }).must_equal true
+        end
+
+        it "shows '<None>' in the credentials column when credentials_provisioned is false" do
+          nodes = [
+            {
+              name: 'n1', mode: 'real', endpoint: '10.0.0.1:22',
+              credentials_provisioned: false, last_converge: '-', status: 'Created'
+            },
+          ]
+          prov = stub_agentless_provisioner(nodes)
+          instance = stub_instance('default-ubuntu-2404', prov)
+          cmd, shell = build_list_cmd([instance])
+          cmd.send(:list_remote_nodes, [instance])
+
+          data_row = shell.table_calls.first[1]
+          _(data_row.any? { |c| c.to_s.include?('<None>') }).must_equal true
+        end
+
+        it 'calls print_table once per agentless instance with nodes' do
+          nodes1 = [{ name: 'n1', mode: 'container', endpoint: '172.17.0.2:22',
+                      credentials_provisioned: true, last_converge: '-', status: 'Set Up' }]
+          nodes2 = [{ name: 'n2', mode: 'real', endpoint: '10.0.0.2:22',
+                      credentials_provisioned: false, last_converge: '-', status: '<Not Created>' }]
+          instances = [
+            stub_instance('default-ubuntu-2404', stub_agentless_provisioner(nodes1)),
+            stub_instance('default-almalinux-9', stub_agentless_provisioner(nodes2)),
+          ]
+          cmd, shell = build_list_cmd(instances)
+          cmd.send(:list_remote_nodes, instances)
+          _(shell.table_calls.size).must_equal 2
+        end
+
+        it 'skips standard instances — only prints tables for agentless ones' do
+          agentless_nodes = [{ name: 'n1', mode: 'container', endpoint: '-',
+                               credentials_provisioned: false, last_converge: '-', status: '<Not Created>' }]
+          instances = [
+            stub_instance('default-ubuntu-2404', stub_standard_provisioner),
+            stub_instance('default-almalinux-9', stub_agentless_provisioner(agentless_nodes)),
+          ]
+          cmd, shell = build_list_cmd(instances)
+          cmd.send(:list_remote_nodes, instances)
+          # Only one print_table call (for the agentless instance)
+          _(shell.table_calls.size).must_equal 1
+        end
+      end
+
+      # ---------------------------------------------------------------------------
+      # #format_node_status
+      # ---------------------------------------------------------------------------
+
+      describe '#format_node_status' do
+        let(:cmd) do
+          c = List.allocate
+          c.instance_variable_set(:@shell, TestShell.new)
+          c
+        end
+
+        it "returns 'Converged' for Converged status" do
+          _(cmd.send(:format_node_status, 'Converged')).must_equal 'Converged'
+        end
+
+        it "returns 'Set Up' for Set Up status" do
+          _(cmd.send(:format_node_status, 'Set Up')).must_equal 'Set Up'
+        end
+
+        it "returns 'Created' for Created status" do
+          _(cmd.send(:format_node_status, 'Created')).must_equal 'Created'
+        end
+
+        it "returns '<Not Created>' for <Not Created> status" do
+          _(cmd.send(:format_node_status, '<Not Created>')).must_equal '<Not Created>'
+        end
+
+        it 'returns the raw string for an unknown status' do
+          _(cmd.send(:format_node_status, 'SomethingElse')).must_equal 'SomethingElse'
+        end
+      end
+
+      # ---------------------------------------------------------------------------
+      # #to_hash — JSON output
+      # ---------------------------------------------------------------------------
+
+      describe '#to_hash' do
+        let(:cmd) do
+          c = List.allocate
+          c.instance_variable_set(:@shell, TestShell.new)
+          c
+        end
+
+        it 'does not include remote_nodes for a standard provisioner' do
+          prov = stub_standard_provisioner
+          instance = stub_instance('default-ubuntu-2404', prov, last_action: 'converge')
+          h = cmd.send(:to_hash, instance)
+          _(h.key?(:remote_nodes)).must_equal false
+        end
+
+        it 'includes remote_nodes for an agentless provisioner' do
+          nodes = [{ name: 'n1', mode: 'container', endpoint: '-',
+                     credentials_provisioned: false, last_converge: '-', status: '<Not Created>' }]
+          prov = stub_agentless_provisioner(nodes)
+          instance = stub_instance('default-ubuntu-2404', prov, last_action: 'converge')
+          h = cmd.send(:to_hash, instance)
+          _(h.key?(:remote_nodes)).must_equal true
+          _(h[:remote_nodes]).must_equal nodes
+        end
+
+        it 'includes standard fields for all instances' do
+          prov = stub_standard_provisioner
+          instance = stub_instance('default-ubuntu-2404', prov, last_action: 'create')
+          h = cmd.send(:to_hash, instance)
+          _(h[:instance]).must_equal 'default-ubuntu-2404'
+          _(h[:driver]).must_equal 'dokken'
+          _(h[:provisioner]).must_equal 'ChefInfra'
+          _(h[:last_action]).must_equal 'create'
+        end
+      end
+    end
+  end
+end

--- a/spec/kitchen/command/list_spec.rb
+++ b/spec/kitchen/command/list_spec.rb
@@ -15,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../../spec_helper'
-require 'kitchen'
-require 'kitchen/logging'
-require 'kitchen/command/list'
+require_relative "../../spec_helper"
+require "kitchen"
+require "kitchen/logging"
+require "kitchen/command/list"
 
 module Kitchen
   module Command
@@ -48,7 +48,7 @@ module Kitchen
       # ---------------------------------------------------------------------------
 
       # Stub a provisioner that does NOT have agentless_node_status (standard).
-      def stub_standard_provisioner(name = 'ChefInfra')
+      def stub_standard_provisioner(name = "ChefInfra")
         p = stub
         p.stubs(:name).returns(name)
         p.stubs(:respond_to?).with(:agentless_node_status).returns(false)
@@ -56,7 +56,7 @@ module Kitchen
       end
 
       # Stub an agentless provisioner with the given node list.
-      def stub_agentless_provisioner(nodes, name = 'ChefInfraAgentless')
+      def stub_agentless_provisioner(nodes, name = "ChefInfraAgentless")
         p = stub
         p.stubs(:name).returns(name)
         p.stubs(:respond_to?).with(:agentless_node_status).returns(true)
@@ -67,9 +67,9 @@ module Kitchen
       # Stub a minimal instance.
       def stub_instance(name, provisioner, last_action: nil, last_error: nil)
         i = stub
-        d = stub(name: 'dokken')
-        v = stub(name: 'inspec')
-        t = stub(name: 'dokken')
+        d = stub(name: "dokken")
+        v = stub(name: "inspec")
+        t = stub(name: "dokken")
         i.stubs(:name).returns(name)
         i.stubs(:driver).returns(d)
         i.stubs(:provisioner).returns(provisioner)
@@ -86,7 +86,7 @@ module Kitchen
         shell = TestShell.new
 
         cmd = List.allocate
-        cmd.instance_variable_set(:@args, ['all'])
+        cmd.instance_variable_set(:@args, ["all"])
         cmd.instance_variable_set(:@options, { json: json, bare: bare, debug: false })
         cmd.instance_variable_set(:@shell, shell)
 
@@ -99,51 +99,51 @@ module Kitchen
       # #list_remote_nodes — display path
       # ---------------------------------------------------------------------------
 
-      describe '#list_remote_nodes' do
-        it 'outputs nothing when no instances use an agentless provisioner' do
+      describe "#list_remote_nodes" do
+        it "outputs nothing when no instances use an agentless provisioner" do
           prov = stub_standard_provisioner
-          instances = [stub_instance('default-ubuntu-2404', prov)]
+          instances = [stub_instance("default-ubuntu-2404", prov)]
           cmd, shell = build_list_cmd(instances)
           cmd.send(:list_remote_nodes, instances)
           _(shell.table_calls).must_be_empty
         end
 
-        it 'outputs nothing when the agentless provisioner returns an empty array' do
+        it "outputs nothing when the agentless provisioner returns an empty array" do
           prov = stub_agentless_provisioner([])
-          instances = [stub_instance('default-ubuntu-2404', prov)]
+          instances = [stub_instance("default-ubuntu-2404", prov)]
           cmd, shell = build_list_cmd(instances)
           cmd.send(:list_remote_nodes, instances)
           _(shell.table_calls).must_be_empty
         end
 
-        it 'calls print_table once for an agentless instance with nodes' do
+        it "calls print_table once for an agentless instance with nodes" do
           nodes = [
             {
-              name: 'edge1', mode: 'container', endpoint: '172.17.0.3:22',
-              credentials_provisioned: true, last_converge: '-', status: 'Set Up'
+              name: "edge1", mode: "container", endpoint: "172.17.0.3:22",
+              credentials_provisioned: true, last_converge: "-", status: "Set Up"
             },
           ]
           prov = stub_agentless_provisioner(nodes)
-          instance = stub_instance('default-ubuntu-2404', prov)
+          instance = stub_instance("default-ubuntu-2404", prov)
           cmd, shell = build_list_cmd([instance])
           cmd.send(:list_remote_nodes, [instance])
           # One print_table call for the one agentless instance
           _(shell.table_calls.size).must_equal 1
         end
 
-        it 'prints a table with one data row per remote node (plus a header row)' do
+        it "prints a table with one data row per remote node (plus a header row)" do
           nodes = [
             {
-              name: 'node-a', mode: 'real', endpoint: '10.0.0.1:22',
-              credentials_provisioned: false, last_converge: '-', status: 'Created'
+              name: "node-a", mode: "real", endpoint: "10.0.0.1:22",
+              credentials_provisioned: false, last_converge: "-", status: "Created"
             },
             {
-              name: 'node-b', mode: 'container', endpoint: '172.17.0.4:22',
-              credentials_provisioned: true, last_converge: '2026-01-01T00:00:00Z', status: 'Converged'
+              name: "node-b", mode: "container", endpoint: "172.17.0.4:22",
+              credentials_provisioned: true, last_converge: "2026-01-01T00:00:00Z", status: "Converged"
             },
           ]
           prov = stub_agentless_provisioner(nodes)
-          instance = stub_instance('default-ubuntu-2404', prov)
+          instance = stub_instance("default-ubuntu-2404", prov)
           cmd, shell = build_list_cmd([instance])
           cmd.send(:list_remote_nodes, [instance])
 
@@ -152,62 +152,62 @@ module Kitchen
           _(rows.size).must_equal 3
           # Node names appear in data rows
           data_rows = rows.drop(1)
-          _(data_rows.any? { |r| r.first.to_s.include?('node-a') }).must_equal true
-          _(data_rows.any? { |r| r.first.to_s.include?('node-b') }).must_equal true
+          _(data_rows.any? { |r| r.first.to_s.include?("node-a") }).must_equal true
+          _(data_rows.any? { |r| r.first.to_s.include?("node-b") }).must_equal true
         end
 
         it "shows 'Provisioned' in the credentials column when credentials_provisioned is true" do
           nodes = [
             {
-              name: 'n1', mode: 'real', endpoint: '10.0.0.1:22',
-              credentials_provisioned: true, last_converge: '-', status: 'Set Up'
+              name: "n1", mode: "real", endpoint: "10.0.0.1:22",
+              credentials_provisioned: true, last_converge: "-", status: "Set Up"
             },
           ]
           prov = stub_agentless_provisioner(nodes)
-          instance = stub_instance('default-ubuntu-2404', prov)
+          instance = stub_instance("default-ubuntu-2404", prov)
           cmd, shell = build_list_cmd([instance])
           cmd.send(:list_remote_nodes, [instance])
 
           data_row = shell.table_calls.first[1] # first data row (after header)
-          _(data_row.any? { |c| c.to_s.include?('Provisioned') }).must_equal true
+          _(data_row.any? { |c| c.to_s.include?("Provisioned") }).must_equal true
         end
 
         it "shows '<None>' in the credentials column when credentials_provisioned is false" do
           nodes = [
             {
-              name: 'n1', mode: 'real', endpoint: '10.0.0.1:22',
-              credentials_provisioned: false, last_converge: '-', status: 'Created'
+              name: "n1", mode: "real", endpoint: "10.0.0.1:22",
+              credentials_provisioned: false, last_converge: "-", status: "Created"
             },
           ]
           prov = stub_agentless_provisioner(nodes)
-          instance = stub_instance('default-ubuntu-2404', prov)
+          instance = stub_instance("default-ubuntu-2404", prov)
           cmd, shell = build_list_cmd([instance])
           cmd.send(:list_remote_nodes, [instance])
 
           data_row = shell.table_calls.first[1]
-          _(data_row.any? { |c| c.to_s.include?('<None>') }).must_equal true
+          _(data_row.any? { |c| c.to_s.include?("<None>") }).must_equal true
         end
 
-        it 'calls print_table once per agentless instance with nodes' do
-          nodes1 = [{ name: 'n1', mode: 'container', endpoint: '172.17.0.2:22',
-                      credentials_provisioned: true, last_converge: '-', status: 'Set Up' }]
-          nodes2 = [{ name: 'n2', mode: 'real', endpoint: '10.0.0.2:22',
-                      credentials_provisioned: false, last_converge: '-', status: '<Not Created>' }]
+        it "calls print_table once per agentless instance with nodes" do
+          nodes1 = [{ name: "n1", mode: "container", endpoint: "172.17.0.2:22",
+                      credentials_provisioned: true, last_converge: "-", status: "Set Up" }]
+          nodes2 = [{ name: "n2", mode: "real", endpoint: "10.0.0.2:22",
+                      credentials_provisioned: false, last_converge: "-", status: "<Not Created>" }]
           instances = [
-            stub_instance('default-ubuntu-2404', stub_agentless_provisioner(nodes1)),
-            stub_instance('default-almalinux-9', stub_agentless_provisioner(nodes2)),
+            stub_instance("default-ubuntu-2404", stub_agentless_provisioner(nodes1)),
+            stub_instance("default-almalinux-9", stub_agentless_provisioner(nodes2)),
           ]
           cmd, shell = build_list_cmd(instances)
           cmd.send(:list_remote_nodes, instances)
           _(shell.table_calls.size).must_equal 2
         end
 
-        it 'skips standard instances — only prints tables for agentless ones' do
-          agentless_nodes = [{ name: 'n1', mode: 'container', endpoint: '-',
-                               credentials_provisioned: false, last_converge: '-', status: '<Not Created>' }]
+        it "skips standard instances — only prints tables for agentless ones" do
+          agentless_nodes = [{ name: "n1", mode: "container", endpoint: "-",
+                               credentials_provisioned: false, last_converge: "-", status: "<Not Created>" }]
           instances = [
-            stub_instance('default-ubuntu-2404', stub_standard_provisioner),
-            stub_instance('default-almalinux-9', stub_agentless_provisioner(agentless_nodes)),
+            stub_instance("default-ubuntu-2404", stub_standard_provisioner),
+            stub_instance("default-almalinux-9", stub_agentless_provisioner(agentless_nodes)),
           ]
           cmd, shell = build_list_cmd(instances)
           cmd.send(:list_remote_nodes, instances)
@@ -220,7 +220,7 @@ module Kitchen
       # #format_node_status
       # ---------------------------------------------------------------------------
 
-      describe '#format_node_status' do
+      describe "#format_node_status" do
         let(:cmd) do
           c = List.allocate
           c.instance_variable_set(:@shell, TestShell.new)
@@ -228,23 +228,23 @@ module Kitchen
         end
 
         it "returns 'Converged' for Converged status" do
-          _(cmd.send(:format_node_status, 'Converged')).must_equal 'Converged'
+          _(cmd.send(:format_node_status, "Converged")).must_equal "Converged"
         end
 
         it "returns 'Set Up' for Set Up status" do
-          _(cmd.send(:format_node_status, 'Set Up')).must_equal 'Set Up'
+          _(cmd.send(:format_node_status, "Set Up")).must_equal "Set Up"
         end
 
         it "returns 'Created' for Created status" do
-          _(cmd.send(:format_node_status, 'Created')).must_equal 'Created'
+          _(cmd.send(:format_node_status, "Created")).must_equal "Created"
         end
 
         it "returns '<Not Created>' for <Not Created> status" do
-          _(cmd.send(:format_node_status, '<Not Created>')).must_equal '<Not Created>'
+          _(cmd.send(:format_node_status, "<Not Created>")).must_equal "<Not Created>"
         end
 
-        it 'returns the raw string for an unknown status' do
-          _(cmd.send(:format_node_status, 'SomethingElse')).must_equal 'SomethingElse'
+        it "returns the raw string for an unknown status" do
+          _(cmd.send(:format_node_status, "SomethingElse")).must_equal "SomethingElse"
         end
       end
 
@@ -252,38 +252,38 @@ module Kitchen
       # #to_hash — JSON output
       # ---------------------------------------------------------------------------
 
-      describe '#to_hash' do
+      describe "#to_hash" do
         let(:cmd) do
           c = List.allocate
           c.instance_variable_set(:@shell, TestShell.new)
           c
         end
 
-        it 'does not include remote_nodes for a standard provisioner' do
+        it "does not include remote_nodes for a standard provisioner" do
           prov = stub_standard_provisioner
-          instance = stub_instance('default-ubuntu-2404', prov, last_action: 'converge')
+          instance = stub_instance("default-ubuntu-2404", prov, last_action: "converge")
           h = cmd.send(:to_hash, instance)
           _(h.key?(:remote_nodes)).must_equal false
         end
 
-        it 'includes remote_nodes for an agentless provisioner' do
-          nodes = [{ name: 'n1', mode: 'container', endpoint: '-',
-                     credentials_provisioned: false, last_converge: '-', status: '<Not Created>' }]
+        it "includes remote_nodes for an agentless provisioner" do
+          nodes = [{ name: "n1", mode: "container", endpoint: "-",
+                     credentials_provisioned: false, last_converge: "-", status: "<Not Created>" }]
           prov = stub_agentless_provisioner(nodes)
-          instance = stub_instance('default-ubuntu-2404', prov, last_action: 'converge')
+          instance = stub_instance("default-ubuntu-2404", prov, last_action: "converge")
           h = cmd.send(:to_hash, instance)
           _(h.key?(:remote_nodes)).must_equal true
           _(h[:remote_nodes]).must_equal nodes
         end
 
-        it 'includes standard fields for all instances' do
+        it "includes standard fields for all instances" do
           prov = stub_standard_provisioner
-          instance = stub_instance('default-ubuntu-2404', prov, last_action: 'create')
+          instance = stub_instance("default-ubuntu-2404", prov, last_action: "create")
           h = cmd.send(:to_hash, instance)
-          _(h[:instance]).must_equal 'default-ubuntu-2404'
-          _(h[:driver]).must_equal 'dokken'
-          _(h[:provisioner]).must_equal 'ChefInfra'
-          _(h[:last_action]).must_equal 'create'
+          _(h[:instance]).must_equal "default-ubuntu-2404"
+          _(h[:driver]).must_equal "dokken"
+          _(h[:provisioner]).must_equal "ChefInfra"
+          _(h[:last_action]).must_equal "create"
         end
       end
     end


### PR DESCRIPTION
<h2>Summary</h2>
<p>Extends <code>kitchen list</code> to print a <strong>Remote Nodes</strong> sub-table beneath the main instance table whenever any instance uses an agentless provisioner. No hard dependency on the plugin gem — detection is duck-typed via <code>respond_to?(:agentless_node_status)</code>.</p>

<h2>Sample output</h2>
<pre>
Instance              Driver  Provisioner          Verifier  Transport  Last Action   Last Error
default-ubuntu-2404   dokken  ChefInfraAgentless   inspec    dokken     Converged     &lt;None&gt;

Remote Nodes: default-ubuntu-2404
  Node              Mode       Endpoint          Credentials   Last Converge
  container-node-1  container  172.17.0.3:22     Provisioned   2026-06-03T15:00:00Z
</pre>

<h2>Changes</h2>
<ul>
<li><strong>lib/kitchen/command/list.rb</strong> — <code>list_remote_nodes</code> private method: iterates instances, duck-checks provisioner, prints per-instance node sub-table via existing <code>print_table</code> shell helper</li>
<li><strong>lib/kitchen/command/list.rb</strong> — <code>format_node_status</code> private helper: color-codes status (Converged=green, Set Up=cyan, Created=yellow, &lt;Not Created&gt;=white)</li>
<li><strong>lib/kitchen/command/list.rb</strong> — <code>to_hash</code> updated to include <code>:remote_nodes</code> array for <code>--json</code> output</li>
<li><strong>spec/kitchen/command/list_spec.rb</strong> (new) — 16 Minitest tests using <code>TestShell</code> capture pattern to inspect <code>print_table</code> calls without Mocha block limitations</li>
</ul>

<h2>Testing</h2>
<ul>
<li>All 2031 tests pass, 0 failures</li>
<li>Cookstyle clean</li>
</ul>

<h2>Related PR</h2>
<p>Plugin PR: chef/kitchen-chef-infra-agentless#16 — provides the <code>agentless_node_status</code> method this code calls</p>