### PR TITLE
[CHEF-27352] Skip credential validation for container-mode remote nodes (TKE core)

### DIFF
--- a/lib/kitchen/agentless/remote_node.rb
+++ b/lib/kitchen/agentless/remote_node.rb
@@ -123,6 +123,11 @@ module Kitchen
       end
 
       def validate_credential_fields!
+        # Container mode uses docker:// transport — no credentials needed.
+        # credential-map-file and credential-passing-mode are ignored for
+        # container nodes.
+        return if container_mode?
+
         if credential_map_file.nil? || credential_map_file.empty?
           raise Kitchen::UserError,
             "Remote node '#{name}' is missing required field 'credential-map-file'"

--- a/spec/kitchen/agentless/remote_node_spec.rb
+++ b/spec/kitchen/agentless/remote_node_spec.rb
@@ -167,18 +167,40 @@ describe Kitchen::Agentless::RemoteNode do
     end
 
     describe "missing credential-map-file" do
-      it "raises UserError" do
-        node = Kitchen::Agentless::RemoteNode.new(container_config("credential-map-file" => nil))
+      it "raises UserError for real-mode nodes" do
+        node = Kitchen::Agentless::RemoteNode.new(
+          "name" => "real-node",
+          "test-kitchen-mode" => "real",
+          "endpoint" => "10.0.0.1:22",
+          "credential-map-file" => nil,
+          "credential-passing-mode" => "pass-by-creds-file"
+        )
         err = _(proc { node.validate! }).must_raise Kitchen::UserError
         _(err.message).must_include "credential-map-file"
+      end
+
+      it "does NOT raise for container-mode nodes (no credentials required)" do
+        node = Kitchen::Agentless::RemoteNode.new(container_config("credential-map-file" => nil))
+        _(proc { node.validate! }).must_be_silent
       end
     end
 
     describe "invalid credential-passing-mode" do
-      it "raises UserError for unknown mode" do
-        node = Kitchen::Agentless::RemoteNode.new(container_config("credential-passing-mode" => "pass-by-magic"))
+      it "raises UserError for unknown mode on real-mode nodes" do
+        node = Kitchen::Agentless::RemoteNode.new(
+          "name" => "real-node",
+          "test-kitchen-mode" => "real",
+          "endpoint" => "10.0.0.1:22",
+          "credential-map-file" => "test/creds.yml",
+          "credential-passing-mode" => "pass-by-magic"
+        )
         err = _(proc { node.validate! }).must_raise Kitchen::UserError
         _(err.message).must_include "pass-by-magic"
+      end
+
+      it "does NOT raise for container-mode nodes even with unknown passing mode" do
+        node = Kitchen::Agentless::RemoteNode.new(container_config("credential-passing-mode" => "pass-by-magic"))
+        _(proc { node.validate! }).must_be_silent
       end
     end
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>Container-mode remote nodes use <code>docker://</code> Train transport —

<h2>Changes</h2>
<ul>
<li><code>spec/kitchen/agentless/remote_node_spec.rb</code>: updated tests — real nodes still require credential fields; container nodes skip validation; added explicit tests for both paths</li>
</ul>

<h2>Testing</h2>
<p>2034 unit tests passing, 0 failures, 0 cookstyle offenses.</p>

<h2>Related PR</h2>
<p>Pair PR in kitchen-chef-infra-agentless: CHEF-container-docker-transport-plugin</p>