### PR TITLE
[CHEF-23408] Generalize provisioner lifecycle hooks via perform_action; minimize list.rb

### DIFF
--- a/lib/kitchen.rb
+++ b/lib/kitchen.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Fletcher Nichol (<fnichol@nichol.ca>)
 #
-# Copyright:: (C) 2012, 2013, 2014 Fletcher Nichol
+# Copyright (C) 2012, 2013, 2014 Fletcher Nichol
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -17,6 +17,7 @@
 
 require_relative "../command"
 require "json" unless defined?(JSON)
+require "set" unless defined?(Set)
 
 module Kitchen
   module Command
@@ -136,134 +137,44 @@ module Kitchen
       end
 
       # Prints a "Remote Nodes" sub-table for each instance whose provisioner
-      # supports {#agentless_node_status}.  Called after the main instance table.
+      # supports {#render_list_section}. Called after the main instance table.
       #
-      # When the same pool node is assigned to multiple instances (pool smaller
-      # than instance count), subsequent occurrences show a "(shared with X)"
-      # annotation instead of repeating the full row.
+      # Builds a cross-instance shared-node map (node_id → first instance name)
+      # so pool nodes assigned to multiple instances are annotated correctly,
+      # then delegates all rendering to the provisioner.
       #
-      # Outputs nothing if no instance is running in agentless mode or if all
-      # provisioners return an empty node list.
+      # Outputs nothing if no instance uses an agentless provisioner.
       #
       # @param result [Array<Instance>] array of instances from parse_subcommand
       # @api private
       def list_remote_nodes(result)
-        agentless_instances = Array(result).select do |i|
-          i.provisioner.respond_to?(:agentless_node_status)
-        end
-        return if agentless_instances.empty?
+        agentless = Array(result).select { |i| i.provisioner.respond_to?(:render_list_section) }
+        return if agentless.empty?
 
-        # Build node_id → first instance name for shared-node detection.
-        node_first_seen = {}
-        agentless_instances.each do |inst|
-          (inst.provisioner.agentless_node_status || []).each do |n|
-            node_first_seen[n[:node_id]] ||= inst.name
-          end
+        first_seen = agentless.each_with_object({}) do |i, map|
+          (i.provisioner.agentless_node_status || []).each { |n| map[n[:node_id]] ||= i.name }
         end
 
-        agentless_instances.each do |instance|
-          nodes = instance.provisioner.agentless_node_status
-          next if nodes.nil? || nodes.empty?
-
-          puts ""
-          puts colorize("Remote Nodes: #{instance.name}", :green)
-
-          table = [[
-            colorize("Node", :green),
-            colorize("Mode", :green),
-            colorize("Endpoint", :green),
-            colorize("Credentials", :green),
-            colorize("Status", :green),
-            colorize("Last Converge", :green),
-          ]]
-
-          nodes.each do |n|
-            first_seen = node_first_seen[n[:node_id]]
-            shared     = first_seen && first_seen != instance.name
-
-            if shared
-              table << [
-                color_pad("#{n[:name]} (shared with #{first_seen})"),
-                color_pad(n[:mode].to_s),
-                color_pad("-"),
-                color_pad("-"),
-                colorize("Shared", :yellow),
-                color_pad("-"),
-              ]
-            else
-              table << [
-                color_pad(n[:name].to_s),
-                color_pad(n[:mode].to_s),
-                color_pad(n[:endpoint].to_s),
-                color_pad(n[:credentials].to_s),
-                format_node_status(n[:status].to_s),
-                color_pad(n[:last_converge].to_s),
-              ]
-            end
-          end
-
-          print_table(table)
-        end
+        agentless.each { |i| i.provisioner.render_list_section(shell, i.name, first_seen) }
       end
 
-      # Prints an "Unused Pool Nodes" section listing pool nodes that are not
-      # assigned to any Kitchen instance in the current run.
+      # Prints an "Unused Pool Nodes" section for pool nodes not assigned to
+      # any Kitchen instance in the current run.
       #
-      # Only appears when at least one provisioner is in pool mode AND the pool
-      # contains more nodes than there are instances.
+      # Delegates rendering to the first pool-aware provisioner found.
       #
       # @param result [Array<Instance>] array of instances from parse_subcommand
       # @api private
       def list_unused_pool_nodes(result)
-        pool_instances = Array(result).select do |i|
-          i.provisioner.respond_to?(:all_pool_nodes) &&
-            !i.provisioner.all_pool_nodes.nil?
+        inst = Array(result).detect { |i| i.provisioner.respond_to?(:render_pool_overflow_section) }
+        return unless inst
+
+        assigned = Array(result).each_with_object(Set.new) do |i, s|
+          next unless i.provisioner.respond_to?(:agentless_node_status)
+
+          i.provisioner.agentless_node_status.each { |n| s << n[:name] }
         end
-        return if pool_instances.empty?
-
-        assigned_names = pool_instances.flat_map do |i|
-          i.provisioner.agentless_node_status.map { |n| n[:name] }
-        end.to_set
-
-        all_nodes = pool_instances.first.provisioner.all_pool_nodes
-        unused    = all_nodes.reject { |n| assigned_names.include?(n[:name]) }
-        return if unused.empty?
-
-        puts ""
-        puts colorize("Unused Pool Nodes", :yellow)
-
-        table = [[
-          colorize("Node", :yellow),
-          colorize("Mode", :yellow),
-          colorize("Endpoint", :yellow),
-        ]]
-
-        unused.each do |n|
-          table << [
-            color_pad(n[:name].to_s),
-            color_pad(n[:mode].to_s),
-            color_pad(n[:endpoint].to_s),
-          ]
-        end
-
-        print_table(table)
-      end
-
-      # Format and color a remote node status string.
-      #
-      # @param status [String]
-      # @return [String]
-      # @api private
-      def format_node_status(status)
-        case status
-        when "Converged"     then colorize("Converged", :magenta)
-        when "Set Up"        then colorize("Set Up", :blue)
-        when "Created"       then colorize("Created", :cyan)
-        when "Ready"         then colorize("Ready", :green)
-        when "<Not Created>" then colorize("<Not Created>", :red)
-        when "Not Set Up"    then colorize("Not Set Up", :yellow)
-        else colorize(status, :white)
-        end
+        inst.provisioner.render_pool_overflow_section(shell, assigned)
       end
 
       # Outputs a formatted display table.

--- a/lib/kitchen/instance.rb
+++ b/lib/kitchen/instance.rb
@@ -402,22 +402,13 @@ module Kitchen
 
     # Perform the create action.
     #
-    # After the driver creates the instance, calls +provisioner.after_create(state)+
-    # if the provisioner responds to that method. This allows agentless provisioners
-    # to record remote-node state and log topology details immediately after the
-    # source container is available.
+    # Perform the create action.
     #
     # @see Driver::Base#create
     # @return [self] this instance, used to chain actions
     # @api private
     def create_action
-      banner "Creating #{to_str}..."
-      elapsed = action(:create) do |state|
-        driver.create(state)
-        provisioner.after_create(state) if provisioner.respond_to?(:after_create)
-      end
-      info("Finished creating #{to_str} #{Util.duration(elapsed.real)}.")
-      self
+      perform_action(:create, "Creating")
     end
 
     # Perform the converge action.
@@ -443,8 +434,8 @@ module Kitchen
     # Perform the setup action.
     #
     # For legacy SSH-base drivers the original setup path is preserved. For all
-    # other drivers, calls +provisioner.setup(state)+ when the provisioner
-    # responds to that method. This allows agentless provisioners to upload
+    # other drivers, calls +provisioner.after_setup(state)+ when the provisioner
+    # responds to that method. This allows provisioner plugins to upload
     # credentials and perform any pre-converge source-container preparation.
     #
     # @see Driver::Base#setup
@@ -454,7 +445,7 @@ module Kitchen
       banner "Setting up #{to_str}..."
       elapsed = action(:setup) do |state|
         legacy_ssh_base_setup(state) if legacy_ssh_base_driver?
-        provisioner.setup(state) if provisioner.respond_to?(:setup)
+        provisioner.after_setup(state) if provisioner.respond_to?(:after_setup)
       end
       info("Finished setting up #{to_str} #{Util.duration(elapsed.real)}.")
       self
@@ -498,36 +489,33 @@ module Kitchen
 
     # Perform the destroy action.
     #
-    # Calls +provisioner.before_destroy(state)+ when the provisioner responds
-    # to that method, giving agentless provisioners a chance to remove uploaded
-    # credentials from the source container before it is torn down. The driver
-    # destroy and state-file cleanup are then performed in the normal way.
-    #
     # @see Driver::Base#destroy
     # @return [self] this instance, used to chain actions
     # @api private
     def destroy_action
-      banner "Destroying #{to_str}..."
-      elapsed = action(:destroy) do |state|
-        provisioner.before_destroy(state) if provisioner.respond_to?(:before_destroy)
-        driver.destroy(state)
-      end
-      info("Finished destroying #{to_str} #{Util.duration(elapsed.real)}.")
-      state_file.destroy
-      self
+      perform_action(:destroy, "Destroying") { state_file.destroy }
     end
 
     # Perform an arbitrary action and provide useful logging.
     #
+    # Calls +provisioner.before_<verb>(state)+ before the driver action and
+    # +provisioner.after_<verb>(state)+ after it, when the provisioner responds
+    # to those methods. This allows provisioner plugins to hook any lifecycle
+    # phase without modifying this class.
+    #
     # @param verb [Symbol] the action to be performed
     # @param output_verb [String] a verb representing the action, suitable for
     #   use in output logging
-    # @yield perform optional work just after action has complted
+    # @yield perform optional work just after action has completed
     # @return [self] this instance, used to chain actions
     # @api private
     def perform_action(verb, output_verb)
       banner "#{output_verb} #{to_str}..."
-      elapsed = action(verb) { |state| driver.public_send(verb, state) }
+      elapsed = action(verb) do |state|
+        provisioner.public_send(:"before_#{verb}", state) if provisioner.respond_to?(:"before_#{verb}")
+        driver.public_send(verb, state)
+        provisioner.public_send(:"after_#{verb}", state) if provisioner.respond_to?(:"after_#{verb}")
+      end
       info("Finished #{output_verb.downcase} #{to_str}" \
         " #{Util.duration(elapsed.real)}.")
       yield if block_given?

--- a/spec/kitchen/command/list_spec.rb
+++ b/spec/kitchen/command/list_spec.rb
@@ -47,20 +47,27 @@ module Kitchen
       # Helpers
       # ---------------------------------------------------------------------------
 
-      # Stub a provisioner that does NOT have agentless_node_status (standard).
+      # Stub a provisioner that does NOT have agentless support (standard).
       def stub_standard_provisioner(name = "ChefInfra")
         p = stub
         p.stubs(:name).returns(name)
+        p.stubs(:respond_to?).with(:render_list_section).returns(false)
+        p.stubs(:respond_to?).with(:render_pool_overflow_section).returns(false)
         p.stubs(:respond_to?).with(:agentless_node_status).returns(false)
         p
       end
 
-      # Stub an agentless provisioner with the given node list.
+      # Stub an agentless provisioner. render_list_section delegates to the shell
+      # via KCAI; here we just stub it to be a no-op so we can verify it is called.
       def stub_agentless_provisioner(nodes, name = "ChefInfraAgentless")
         p = stub
         p.stubs(:name).returns(name)
+        p.stubs(:respond_to?).with(:render_list_section).returns(true)
+        p.stubs(:respond_to?).with(:render_pool_overflow_section).returns(true)
         p.stubs(:respond_to?).with(:agentless_node_status).returns(true)
         p.stubs(:agentless_node_status).returns(nodes)
+        p.stubs(:render_list_section)
+        p.stubs(:render_pool_overflow_section)
         p
       end
 
@@ -96,163 +103,66 @@ module Kitchen
       end
 
       # ---------------------------------------------------------------------------
-      # #list_remote_nodes — display path
+      # #list_remote_nodes — delegation to provisioner
       # ---------------------------------------------------------------------------
 
       describe "#list_remote_nodes" do
         it "outputs nothing when no instances use an agentless provisioner" do
           prov = stub_standard_provisioner
           instances = [stub_instance("default-ubuntu-2404", prov)]
-          cmd, shell = build_list_cmd(instances)
+          cmd, _shell = build_list_cmd(instances)
+          prov.expects(:render_list_section).never
           cmd.send(:list_remote_nodes, instances)
-          _(shell.table_calls).must_be_empty
         end
 
-        it "outputs nothing when the agentless provisioner returns an empty array" do
-          prov = stub_agentless_provisioner([])
-          instances = [stub_instance("default-ubuntu-2404", prov)]
-          cmd, shell = build_list_cmd(instances)
-          cmd.send(:list_remote_nodes, instances)
-          _(shell.table_calls).must_be_empty
-        end
-
-        it "calls print_table once for an agentless instance with nodes" do
-          nodes = [
-            {
-              name: "edge1", mode: "container", endpoint: "172.17.0.3:22",
-              credentials: "Configured", last_converge: "-", status: "Set Up"
-            },
-          ]
+        it "calls render_list_section on each agentless provisioner" do
+          nodes = [{ name: "edge1", node_id: "id1", mode: "container",
+                     endpoint: "172.17.0.3:22", credentials: "Configured",
+                     last_converge: "-", status: "Created" }]
           prov = stub_agentless_provisioner(nodes)
           instance = stub_instance("default-ubuntu-2404", prov)
           cmd, shell = build_list_cmd([instance])
+          expected_map = { "id1" => "default-ubuntu-2404" }
+          prov.expects(:render_list_section).with(shell, "default-ubuntu-2404", expected_map)
           cmd.send(:list_remote_nodes, [instance])
-          # One print_table call for the one agentless instance
-          _(shell.table_calls.size).must_equal 1
         end
 
-        it "prints a table with one data row per remote node (plus a header row)" do
-          nodes = [
-            {
-              name: "node-a", mode: "real", endpoint: "10.0.0.1:22",
-              credentials: "<None>", last_converge: "-", status: "Created"
-            },
-            {
-              name: "node-b", mode: "container", endpoint: "172.17.0.4:22",
-              credentials: "Configured", last_converge: "2026-01-01T00:00:00Z", status: "Converged"
-            },
-          ]
-          prov = stub_agentless_provisioner(nodes)
-          instance = stub_instance("default-ubuntu-2404", prov)
-          cmd, shell = build_list_cmd([instance])
-          cmd.send(:list_remote_nodes, [instance])
+        it "builds a first_seen map across instances and passes it to each provisioner" do
+          node_id = "shared-node-id"
+          nodes_a = [{ name: "n1", node_id: node_id, mode: "container",
+                       endpoint: "-", credentials: "Container Key",
+                       last_converge: "-", status: "<Not Created>" }]
+          nodes_b = [{ name: "n1", node_id: node_id, mode: "container",
+                       endpoint: "-", credentials: "Container Key",
+                       last_converge: "-", status: "<Not Created>" }]
+          prov_a = stub_agentless_provisioner(nodes_a)
+          prov_b = stub_agentless_provisioner(nodes_b)
+          inst_a = stub_instance("default-ubuntu-2404", prov_a)
+          inst_b = stub_instance("default-almalinux-9", prov_b)
+          cmd, shell = build_list_cmd([inst_a, inst_b])
 
-          # 1 header row + 2 data rows
-          rows = shell.table_calls.first
-          _(rows.size).must_equal 3
-          # Node names appear in data rows
-          data_rows = rows.drop(1)
-          _(data_rows.any? { |r| r.first.to_s.include?("node-a") }).must_equal true
-          _(data_rows.any? { |r| r.first.to_s.include?("node-b") }).must_equal true
+          expected_map = { node_id => "default-ubuntu-2404" }
+          prov_a.expects(:render_list_section).with(shell, "default-ubuntu-2404", expected_map)
+          prov_b.expects(:render_list_section).with(shell, "default-almalinux-9", expected_map)
+
+          cmd.send(:list_remote_nodes, [inst_a, inst_b])
         end
 
-        it "shows 'Configured' in the credentials column for real nodes with credential-map-file" do
-          nodes = [
-            {
-              name: "n1", mode: "real", endpoint: "10.0.0.1:22",
-              credentials: "Configured", last_converge: "-", status: "Set Up"
-            },
-          ]
-          prov = stub_agentless_provisioner(nodes)
-          instance = stub_instance("default-ubuntu-2404", prov)
-          cmd, shell = build_list_cmd([instance])
-          cmd.send(:list_remote_nodes, [instance])
-
-          data_row = shell.table_calls.first[1] # first data row (after header)
-          _(data_row.any? { |c| c.to_s.include?("Configured") }).must_equal true
-        end
-
-        it "shows '<None>' in the credentials column for real nodes without credential-map-file" do
-          nodes = [
-            {
-              name: "n1", mode: "real", endpoint: "10.0.0.1:22",
-              credentials: "<None>", last_converge: "-", status: "Created"
-            },
-          ]
-          prov = stub_agentless_provisioner(nodes)
-          instance = stub_instance("default-ubuntu-2404", prov)
-          cmd, shell = build_list_cmd([instance])
-          cmd.send(:list_remote_nodes, [instance])
-
-          data_row = shell.table_calls.first[1]
-          _(data_row.any? { |c| c.to_s.include?("<None>") }).must_equal true
-        end
-
-        it "calls print_table once per agentless instance with nodes" do
-          nodes1 = [{ name: "n1", mode: "container", endpoint: "172.17.0.2:22",
-                      credentials: "Container Key", last_converge: "-", status: "Set Up" }]
-          nodes2 = [{ name: "n2", mode: "real", endpoint: "10.0.0.2:22",
-                      credentials: "<None>", last_converge: "-", status: "<Not Created>" }]
+        it "skips standard instances — only calls render on agentless provisioners" do
+          nodes = [{ name: "n1", node_id: "id1", mode: "container",
+                     endpoint: "-", credentials: "Container Key",
+                     last_converge: "-", status: "<Not Created>" }]
+          std_prov = stub_standard_provisioner
+          agl_prov = stub_agentless_provisioner(nodes)
           instances = [
-            stub_instance("default-ubuntu-2404", stub_agentless_provisioner(nodes1)),
-            stub_instance("default-almalinux-9", stub_agentless_provisioner(nodes2)),
+            stub_instance("default-ubuntu-2404", std_prov),
+            stub_instance("default-almalinux-9", agl_prov),
           ]
           cmd, shell = build_list_cmd(instances)
+          expected_map = { "id1" => "default-almalinux-9" }
+          std_prov.expects(:render_list_section).never
+          agl_prov.expects(:render_list_section).with(shell, "default-almalinux-9", expected_map)
           cmd.send(:list_remote_nodes, instances)
-          _(shell.table_calls.size).must_equal 2
-        end
-
-        it "skips standard instances — only prints tables for agentless ones" do
-          agentless_nodes = [{ name: "n1", mode: "container", endpoint: "-",
-                               credentials: "Container Key", last_converge: "-", status: "<Not Created>" }]
-          instances = [
-            stub_instance("default-ubuntu-2404", stub_standard_provisioner),
-            stub_instance("default-almalinux-9", stub_agentless_provisioner(agentless_nodes)),
-          ]
-          cmd, shell = build_list_cmd(instances)
-          cmd.send(:list_remote_nodes, instances)
-          # Only one print_table call (for the agentless instance)
-          _(shell.table_calls.size).must_equal 1
-        end
-      end
-
-      # ---------------------------------------------------------------------------
-      # #format_node_status
-      # ---------------------------------------------------------------------------
-
-      describe "#format_node_status" do
-        let(:cmd) do
-          c = List.allocate
-          c.instance_variable_set(:@shell, TestShell.new)
-          c
-        end
-
-        it "returns 'Converged' for Converged status" do
-          _(cmd.send(:format_node_status, "Converged")).must_equal "Converged"
-        end
-
-        it "returns 'Set Up' for Set Up status" do
-          _(cmd.send(:format_node_status, "Set Up")).must_equal "Set Up"
-        end
-
-        it "returns 'Created' for Created status" do
-          _(cmd.send(:format_node_status, "Created")).must_equal "Created"
-        end
-
-        it "returns 'Ready' for Ready status (real nodes post-create)" do
-          _(cmd.send(:format_node_status, "Ready")).must_equal "Ready"
-        end
-
-        it "returns '<Not Created>' for <Not Created> status" do
-          _(cmd.send(:format_node_status, "<Not Created>")).must_equal "<Not Created>"
-        end
-
-        it "returns 'Not Set Up' for Not Set Up status (real nodes pre-create)" do
-          _(cmd.send(:format_node_status, "Not Set Up")).must_equal "Not Set Up"
-        end
-
-        it "returns the raw string for an unknown status" do
-          _(cmd.send(:format_node_status, "SomethingElse")).must_equal "SomethingElse"
         end
       end
 

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -1337,7 +1337,7 @@ describe Kitchen::Instance do
 
       hooked_instance.create
 
-      _(order).must_equal %i[before_create driver_create]
+      _(order).must_equal %i{before_create driver_create}
     end
 
     it "calls provisioner.after_create after driver.create" do
@@ -1347,7 +1347,7 @@ describe Kitchen::Instance do
 
       hooked_instance.create
 
-      _(order).must_equal %i[driver_create after_create]
+      _(order).must_equal %i{driver_create after_create}
     end
 
     it "calls provisioner.before_destroy before driver.destroy" do
@@ -1357,7 +1357,7 @@ describe Kitchen::Instance do
 
       hooked_instance.destroy
 
-      _(order).must_equal %i[before_destroy driver_destroy]
+      _(order).must_equal %i{before_destroy driver_destroy}
     end
 
     it "calls provisioner.after_destroy after driver.destroy" do
@@ -1367,7 +1367,7 @@ describe Kitchen::Instance do
 
       hooked_instance.destroy
 
-      _(order).must_equal %i[driver_destroy after_destroy]
+      _(order).must_equal %i{driver_destroy after_destroy}
     end
 
     it "does not call before_create when provisioner does not respond to it" do

--- a/spec/kitchen/instance_spec.rb
+++ b/spec/kitchen/instance_spec.rb
@@ -1305,6 +1305,81 @@ describe Kitchen::Instance do
     end
   end
 
+  describe "provisioner lifecycle hooks via perform_action" do
+    let(:hooked_provisioner) do
+      p = provisioner.dup
+      p.instance_variable_set(:@hooks_called, [])
+      p.define_singleton_method(:before_create)  { |_s| @hooks_called << :before_create }
+      p.define_singleton_method(:after_create)   { |_s| @hooks_called << :after_create }
+      p.define_singleton_method(:before_destroy) { |_s| @hooks_called << :before_destroy }
+      p.define_singleton_method(:after_destroy)  { |_s| @hooks_called << :after_destroy }
+      p.define_singleton_method(:hooks_called)   { @hooks_called }
+      p
+    end
+
+    let(:hooked_instance) do
+      Kitchen::Instance.new(
+        suite: suite,
+        platform: platform,
+        driver: driver,
+        provisioner: hooked_provisioner,
+        verifier: verifier,
+        transport: transport,
+        state_file: state_file,
+        lifecycle_hooks: lifecycle_hooks
+      )
+    end
+
+    it "calls provisioner.before_create before driver.create" do
+      order = []
+      hooked_provisioner.define_singleton_method(:before_create) { |_s| order << :before_create }
+      driver.define_singleton_method(:create)                    { |_s| order << :driver_create }
+
+      hooked_instance.create
+
+      _(order).must_equal %i[before_create driver_create]
+    end
+
+    it "calls provisioner.after_create after driver.create" do
+      order = []
+      driver.define_singleton_method(:create)                   { |_s| order << :driver_create }
+      hooked_provisioner.define_singleton_method(:after_create) { |_s| order << :after_create }
+
+      hooked_instance.create
+
+      _(order).must_equal %i[driver_create after_create]
+    end
+
+    it "calls provisioner.before_destroy before driver.destroy" do
+      order = []
+      hooked_provisioner.define_singleton_method(:before_destroy) { |_s| order << :before_destroy }
+      driver.define_singleton_method(:destroy)                    { |_s| order << :driver_destroy }
+
+      hooked_instance.destroy
+
+      _(order).must_equal %i[before_destroy driver_destroy]
+    end
+
+    it "calls provisioner.after_destroy after driver.destroy" do
+      order = []
+      driver.define_singleton_method(:destroy)                   { |_s| order << :driver_destroy }
+      hooked_provisioner.define_singleton_method(:after_destroy) { |_s| order << :after_destroy }
+
+      hooked_instance.destroy
+
+      _(order).must_equal %i[driver_destroy after_destroy]
+    end
+
+    it "does not call before_create when provisioner does not respond to it" do
+      # default provisioner (no hooks defined) — must not raise
+      instance.create
+    end
+
+    it "does not call before_destroy when provisioner does not respond to it" do
+      instance.destroy
+    end
+  end
+
   describe Kitchen::Instance::FSM do
     let(:fsm) { Kitchen::Instance::FSM }
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>Wave 11 TKE changes: generalize agentless hooks via <code>perform_action</code> and minimize <code>command/list.rb</code> agentless surface by delegating rendering to the provisioner plugin.</p>

<h2>Jira</h2>
<p><a href="https://progresssoftware.atlassian.net/browse/CHEF-23408">CHEF-23408</a></p>

<h2>Changes</h2>
<ul>
<li><code>lib/kitchen/instance.rb</code> — <code>perform_action</code>: +2 lines for before_#{verb}/after_#{verb} hooks; <code>create_action</code>: reverted to upstream one-liner; <code>destroy_action</code>: reverted to upstream one-liner; <code>setup_action</code>: renamed :setup → :after_setup hook</li>
<li><code>lib/kitchen/command/list.rb</code> — <code>list_remote_nodes</code>: -43 lines → delegates to provisioner.render_list_section; <code>list_unused_pool_nodes</code>: -24 lines → delegates to provisioner.render_pool_overflow_section; <code>format_node_status</code>: deleted (moved to KCAI)</li>
<li><code>spec/kitchen/instance_spec.rb</code> — 6 new tests for before_create/after_create/before_destroy/after_destroy hook ordering</li>
<li><code>spec/kitchen/command/list_spec.rb</code> — updated to verify delegation pattern</li>
</ul>

<h2>Testing</h2>
<ul>
<li>1952 runs, 0 failures, 0 errors</li>
<li>cookstyle --chefstyle: 0 offenses</li>
</ul>

<h2>TKE diff vs upstream test-kitchen after this PR</h2>
<ul>
<li><code>create_action</code>: <strong>identical to upstream</strong> ✅</li>
<li><code>destroy_action</code>: <strong>identical to upstream</strong> ✅</li>
<li><code>setup_action</code>: +1 line (after_setup hook)</li>
<li><code>perform_action</code>: +2 lines (before/after hooks)</li>
</ul>

<h2>Merge Order</h2>
<p>⚠️ Merge KCAI PR #19 (<code>kcai-rename-setup-to-after-setup</code>) <strong>first</strong> — this PR calls <code>after_setup</code> and the render methods defined there.</p>