### PR TITLE
Fix GEM_PATH leak into target-side subprocesses in exec transport

### DIFF
--- a/lib/kitchen/transport/exec.rb
+++ b/lib/kitchen/transport/exec.rb
@@ -44,7 +44,7 @@ module Kitchen
             run_command(run_from_file_command(command))
             close
           else
-            run_command(command)
+            run_command(command, environment: ruby_env_sanitized)
           end
         end
 
@@ -123,6 +123,23 @@ module Kitchen
           else
             false
           end
+        end
+
+        # Ruby/Bundler env vars set by TKE's hab binstub (via binstub_patch.rb).
+        # These must not leak into target-side subprocesses: each hab package
+        # (e.g. chef-infra-client) manages its own gem environment via its own
+        # binstub_patch.rb. When TKE's GEM_PATH and APPBUNDLER_ALLOW_RVM are
+        # inherited, the target package's binstub_patch guard is bypassed and
+        # gem activation fails with version mismatches.
+        RUBY_ENV_VARS = %w{GEM_PATH GEM_HOME GEM_SPEC_CACHE BUNDLE_GEMFILE
+                           BUNDLE_BIN_PATH BUNDLE_PATH RUBYLIB RUBYOPT
+                           APPBUNDLER_ALLOW_RVM}.freeze
+
+        # Returns an environment hash that unsets Ruby/Bundler vars for the
+        # subprocess. Mixlib::ShellOut treats nil values as "unset this var".
+        # TKE's own process ENV is not mutated.
+        def ruby_env_sanitized
+          RUBY_ENV_VARS.to_h { |var| [var, nil] }
         end
       end
 

--- a/spec/kitchen/transport/exec_spec.rb
+++ b/spec/kitchen/transport/exec_spec.rb
@@ -110,7 +110,7 @@ describe Kitchen::Transport::Exec::Connection do
 
   describe "#execute" do
     it "runs the command" do
-      connection.expects(:run_command).with("do the thing")
+      connection.expects(:run_command).with("do the thing", environment: Kitchen::Transport::Exec::Connection::RUBY_ENV_VARS.to_h { |v| [v, nil] })
       connection.execute("do the thing")
     end
 


### PR DESCRIPTION
<h2>Problem</h2>

<p>TKE runs as a Habitat package. Its <code>binstub_patch.rb</code> sets <code>GEM_PATH</code> and <code>APPBUNDLER_ALLOW_RVM</code> in the process environment so TKE can locate its vendored gems:</p>

<pre><code>ENV["APPBUNDLER_ALLOW_RVM"] = "true"
ENV["GEM_PATH"] = hab_vendor  # TKE vendor dir
</code></pre>

<p>When the <strong>exec transport</strong> spawns target-side subprocesses (lifecycle hooks, chef-client converge, inspec verify) via <code>Mixlib::ShellOut</code>, those subprocesses inherit the full parent process environment — including TKE's <code>GEM_PATH</code>.</p>

<p>Every hab package (e.g. <code>chef-infra-client</code>) has its own <code>binstub_patch.rb</code> that sets up <code>GEM_PATH</code> to point to its own vendor directory. This patch is guarded by <code>APPBUNDLER_ALLOW_RVM</code>:</p>

<pre><code>unless ENV["APPBUNDLER_ALLOW_RVM"]
  ENV["GEM_PATH"] = [this_pkg_vendor, ENV["GEM_PATH"]].compact.join(":")
end
</code></pre>

<p>Because TKE has already set <code>APPBUNDLER_ALLOW_RVM = "true"</code>, the guard fires and the target package's binstub_patch is <strong>skipped entirely</strong>. The subprocess is left with only TKE's <code>GEM_PATH</code>, causing gem version mismatches:</p>

<pre><code>Could not find 'aws-partitions' (= 1.1261.0) - did find: [aws-partitions-1.1266.0]
Checked in 'GEM_PATH=/opt/hab/pkgs/ashiqueps/chef-test-kitchen-enterprise/2.0.15/.../vendor'
</code></pre>

<h2>Fix</h2>

<p>In <code>Kitchen::Transport::Exec::Connection#execute</code>, pass a sanitized environment to <code>Mixlib::ShellOut</code> that unsets <code>GEM_PATH</code>, <code>GEM_HOME</code>, <code>APPBUNDLER_ALLOW_RVM</code>, and related Ruby/Bundler vars before spawning the subprocess. <code>Mixlib::ShellOut</code> treats <code>nil</code> values as "unset this variable". <strong>TKE's own process <code>ENV</code> is not mutated</strong> — only the subprocess copy is affected.</p>

<p>With the fix:</p>
<ol>
  <li>Subprocess starts with <code>GEM_PATH=nil</code>, <code>APPBUNDLER_ALLOW_RVM=nil</code></li>
  <li>chef-client's <code>binstub_patch.rb</code> guard evaluates to <code>false</code> — patch runs</li>
  <li><code>GEM_PATH</code> is set to chef-infra-client's own vendor dir</li>
  <li>Gem activation finds the correct pinned versions ✅</li>
</ol>

<h2>Why only exec transport is affected</h2>

<table>
<thead><tr><th>Transport</th><th>How commands run on target</th><th>GEM_PATH leaks?</th></tr></thead>
<tbody>
<tr><td><strong>exec</strong></td><td><code>Mixlib::ShellOut</code> fork — inherits full parent <code>ENV</code></td><td>✅ YES — fixed here</td></tr>
<tr><td>SSH (vagrant/ssh)</td><td><code>ssh host "cmd"</code> → new remote login shell</td><td>No — SSH does not forward client env to remote</td></tr>
<tr><td>WinRM</td><td>Remote PowerShell session</td><td>No — fully isolated remote session</td></tr>
<tr><td>Dokken</td><td><code>docker exec</code> → fresh container environment</td><td>No — container env is independent of host</td></tr>
<tr><td>Windows exec</td><td>PowerShell <code>.ps1</code> script via <code>Mixlib::ShellOut</code></td><td>No — chef-client binstub is a <code>.bat</code> file, not Ruby; GEM_PATH is irrelevant</td></tr>
</tbody>
</table>