### PR TITLE
CHEF-36826: --keep-agentless-source flag + Agentless Source section in kitchen list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Full wave plan: `CHEF-23408-WAVE-PLAN.md` in this repo.
 ## Development Workflow Rules
 
 ### Branch Strategy
+
 - **All feature branches must be checked out from `agentless-dev-latest`**
 - **All PRs must target `agentless-dev-latest`** (never `main` directly)
 - Branch naming: `<JIRA-KEY>` — e.g. `CHEF-27348`, `CHEF-36826`
@@ -48,7 +49,9 @@ git checkout -b CHEF-XXXXX
 ```
 
 ### PR Requirements
+
 Every PR must have:
+
 - **`ai-assisted` label** (mandatory, no exceptions)
 - Base branch: `agentless-dev-latest`
 - Title: `CHEF-XXXXX: <description>`
@@ -67,7 +70,7 @@ gh pr create \
 
 ## Repository Structure
 
-```
+```text
 chef-test-kitchen-enterprise/
 ├── bin/
 │   └── kitchen                  # CLI entry point (rarely changed)
@@ -104,11 +107,13 @@ chef-test-kitchen-enterprise/
 **Goal:** Remove all agentless-specific code from TKE core, ensuring non-agentless kitchen.yml files continue to work unchanged.
 
 **What to delete:**
+
 ```bash
 rm -rf lib/kitchen/agentless/
 ```
 
 **What to remove from `lib/kitchen/provisioner/base.rb`:**
+
 ```ruby
 # Remove these:
 default_config :agentless, {}
@@ -119,6 +124,7 @@ end
 ```
 
 **Verification:**
+
 ```bash
 bundle exec rake test   # all existing tests must still pass
 ```

--- a/lib/kitchen/cli.rb
+++ b/lib/kitchen/cli.rb
@@ -186,6 +186,13 @@ module Kitchen
           default: false,
           desc: "Run the #{action} with debugging enabled."
       end
+      if action == :destroy
+        method_option :keep_agentless_source,
+          aliases: "-k",
+          type: :boolean,
+          default: false,
+          desc: "Keep the agentless source node running after destroying targets"
+      end
       method_option :fail_fast,
         aliases: "-f",
         type: :boolean,
@@ -195,7 +202,8 @@ module Kitchen
       log_options
       define_method(action) do |*args|
         update_config!
-        perform(action, "action", args)
+        command = action == :destroy ? "destroy" : "action"
+        perform(action, command, args)
       end
     end
 

--- a/lib/kitchen/command/destroy.rb
+++ b/lib/kitchen/command/destroy.rb
@@ -1,0 +1,46 @@
+#
+# Author:: GitHub Copilot (<support@github.com>)
+#
+# Copyright (C) 2026, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "action"
+
+module Kitchen
+  module Command
+    # Command to destroy one or more instances.
+    class Destroy < Action
+      # Invoke the command.
+      def call
+        banner "Starting Chef Test Kitchen Enterprise (v#{Kitchen::VERSION})"
+        elapsed = Benchmark.measure do
+          results = parse_subcommand(args.first)
+          apply_driver_overrides(Array(results))
+          run_action(action, results)
+        end
+        banner "Chef Test Kitchen Enterprise is finished. #{Util.duration(elapsed.real)}"
+      end
+
+      private
+
+      def apply_driver_overrides(instances)
+        return unless options[:keep_agentless_source]
+
+        instances.each do |instance|
+          instance.driver.send(:config)[:keep_agentless_source] = true
+        end
+      end
+    end
+  end
+end

--- a/lib/kitchen/command/list.rb
+++ b/lib/kitchen/command/list.rb
@@ -36,6 +36,7 @@ module Kitchen
           puts JSON.pretty_generate(Array(result).map { |r| to_hash(r) })
         else
           list_table(result)
+          render_source_info(Array(result))
         end
       end
 
@@ -111,6 +112,26 @@ module Kitchen
         ]
         table += Array(result).map { |i| display_instance(i) }
         print_table(table)
+      end
+
+      def render_source_info(instances)
+        source = instances.filter_map do |instance|
+          next unless instance.driver.respond_to?(:source_info)
+
+          instance.driver.source_info
+        end.first
+
+        return unless source
+
+        print_table(
+          [
+            ["Agentless Source", ""],
+            ["  Hostname", source[:hostname] || "unknown"],
+            ["  Port", (source[:port] || 22).to_s],
+            ["  Driver", source[:driver] || "unknown"],
+            ["  State", source[:state] || "unknown"],
+          ]
+        )
       end
 
       # Constructs a hashtable representation of a single instance.

--- a/spec/kitchen/cli_spec.rb
+++ b/spec/kitchen/cli_spec.rb
@@ -49,5 +49,15 @@ module Kitchen
         assert_equal false, cli.config.log_overwrite
       end
     end
+
+    describe "destroy options" do
+      it "defines keep_agentless_source for destroy" do
+        option = CLI.all_tasks["destroy"].options[:keep_agentless_source]
+
+        _(option).wont_be_nil
+        _(option.aliases).must_include "-k"
+        _(option.default).must_equal false
+      end
+    end
   end
 end

--- a/spec/kitchen/command/destroy_spec.rb
+++ b/spec/kitchen/command/destroy_spec.rb
@@ -1,0 +1,94 @@
+#
+# Author:: GitHub Copilot (<support@github.com>)
+#
+# Copyright (C) 2026, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../spec_helper"
+
+require "kitchen/command/destroy"
+
+module Kitchen
+  module Command
+    describe Destroy do
+      class DriverConfigStub
+        def initialize
+          @config = {}
+        end
+
+        private
+
+        attr_reader :config
+      end
+
+      class InstanceStub
+        attr_reader :driver, :destroyed, :cleaned_up
+
+        def initialize(driver)
+          @driver = driver
+          @destroyed = false
+          @cleaned_up = false
+        end
+
+        def destroy
+          @destroyed = true
+        end
+
+        def cleanup!
+          @cleaned_up = true
+        end
+
+        def name
+          "default-ubuntu-2204"
+        end
+      end
+
+      let(:driver) { DriverConfigStub.new }
+      let(:instance) { InstanceStub.new(driver) }
+      let(:config) { stub(instances: [instance]) }
+
+      it "passes keep_agentless_source through to the driver config" do
+        command = Destroy.new(
+          ["all"],
+          { keep_agentless_source: true },
+          config:,
+          shell: Object.new,
+          help: -> { nil },
+          action: "destroy"
+        )
+
+        command.call
+
+        _(instance.destroyed).must_equal true
+        _(instance.cleaned_up).must_equal true
+        _(driver.send(:config)[:keep_agentless_source]).must_equal true
+      end
+
+      it "does not set keep_agentless_source when the flag is omitted" do
+        command = Destroy.new(
+          ["all"],
+          {},
+          config:,
+          shell: Object.new,
+          help: -> { nil },
+          action: "destroy"
+        )
+
+        command.call
+
+        _(driver.send(:config).key?(:keep_agentless_source)).must_equal false
+      end
+    end
+  end
+end

--- a/spec/kitchen/command/list_spec.rb
+++ b/spec/kitchen/command/list_spec.rb
@@ -1,0 +1,102 @@
+#
+# Author:: GitHub Copilot (<support@github.com>)
+#
+# Copyright (C) 2026, Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative "../../spec_helper"
+
+require "kitchen/command/list"
+
+module Kitchen
+  module Command
+    describe List do
+      class FakeShell
+        attr_reader :tables
+
+        def initialize
+          @tables = []
+        end
+
+        def print_table(table)
+          @tables << table
+        end
+
+        def set_color(string, *_args)
+          string
+        end
+      end
+
+      let(:shell) { FakeShell.new }
+      let(:driver) do
+        stub(
+          name: "agentless",
+          source_info: {
+            hostname: "source.example",
+            port: 2200,
+            driver: "docker",
+            state: "running",
+          }
+        )
+      end
+      let(:command) do
+        List.new(["all"], {}, config: stub(instances: [instance]), shell: shell, help: -> { nil })
+      end
+      let(:instance) do
+        stub(
+          name: "default-ubuntu-2204",
+          driver: driver,
+          provisioner: stub(name: "chef_zero"),
+          verifier: stub(name: "inspec"),
+          transport: stub(name: "ssh"),
+          last_action: "create",
+          last_error: nil
+        )
+      end
+
+      it "does not render an Agentless Source section when no driver exposes source_info" do
+        driver = stub(name: "dummy")
+        instance = stub(
+          name: "default-ubuntu-2204",
+          driver:,
+          provisioner: stub(name: "chef_zero"),
+          verifier: stub(name: "inspec"),
+          transport: stub(name: "ssh"),
+          last_action: "create",
+          last_error: nil
+        )
+        command = List.new(["all"], {}, config: stub(instances: [instance]), shell: shell, help: -> { nil })
+
+        command.call
+
+        _(shell.tables.length).must_equal 1
+      end
+
+      it "renders an Agentless Source section when a driver provides source_info" do
+        command.call
+
+        _(shell.tables.length).must_equal 2
+        _(shell.tables.last).must_equal(
+          [
+            ["Agentless Source", ""],
+            ["  Hostname", "source.example"],
+            ["  Port", "2200"],
+            ["  Driver", "docker"],
+            ["  State", "running"],
+          ]
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Minimal TKE core changes to support agentless lifecycle UX. All runtime logic remains generic and driver-agnostic.

## Story
CHEF-36826: Lifecycle UX — destroy behaviours + kitchen list

## Changed files
- lib/kitchen/command/list.rb — render Agentless Source section via driver#source_info duck typing
- lib/kitchen/command/destroy.rb — apply destroy-time driver config overrides
- lib/kitchen/cli.rb — minimal destroy flag wiring required on this branch to expose --keep-agentless-source

## Design
- No driver-specific conditionals anywhere
- destroy passes the flag as a driver config option so any driver can read it
- list calls driver.source_info only when the method exists via respond_to?

## Acceptance Criteria
- [x] kitchen destroy --keep-agentless-source skips source destruction
- [x] kitchen list shows Agentless Source section when driver provides source_info
- [x] Section hidden when source_info returns nil (local mode, not created)
