### PR TITLE
Pin net-ping to 2.0.8 to fix unit test CI failure

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,11 @@ group :integration do
   gem "kitchen-azurerm", ">= 1.13.6"
   gem "kitchen-hyperv", ">= 0.10.3"
   gem "kitchen-vcenter", ">= 2.12.3"
+  # net-ping 2.1.0+ introduced a transitive dependency on the "cap2" gem,
+  # which requires native compilation against libcap2 headers not present
+  # on our CI runners. Pin to 2.0.8 (last version without this dependency)
+  # until CI images are updated or upstream removes the cap2 dependency.
+  gem "net-ping", "= 2.0.8"
   gem "chef", ">= 19.1" # Chef-CLI depends on chef. This ensures we are getting a newer version
   # Check if Artifactory is accessible, otherwise use GitHub
   artifactory_url = "https://artifactory-internal.ps.chef.co/artifactory/api/gems/omnibus-gems-local"


### PR DESCRIPTION
<h2>Summary</h2>
<p>Fixes the failing "Unit Test (ubuntu, Ruby 3.4)" CI job seen on PR #125 (and likely any PR/main run) where <code>bundle install</code> fails.</p>

<h2>Root Cause</h2>
<p><code>kitchen-vcenter</code> depends on <code>net-ping</code>, which resolves to the latest 2.1.0. That version introduced a new transitive dependency on the <code>cap2</code> gem, which requires compiling a native extension against <code>libcap2</code> headers (<code>sys/capability.h</code>) that are not installed on our GitHub Actions runners. This causes <code>bundle install</code> to fail with:</p>
<pre>
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
sys/capability.h is missing. You should install the libcap2 header files
An error occurred while installing cap2 (0.2.2), and Bundler cannot continue.
</pre>

<h2>Fix</h2>
<p>Pin <code>net-ping</code> to <code>2.0.8</code> in the <code>Gemfile</code> (the last version without the <code>cap2</code> dependency) until CI images are updated to include <code>libcap2-dev</code> or upstream removes the dependency.</p>

<h2>Testing</h2>
<ul>
<li>No Ruby source changes; verifying via CI unit test job on this PR.</li>
</ul>