### PR TITLE
Port and update agentless dev-process scaffolding (skills, instructions, copilot config)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -927,6 +927,88 @@ gh pr create \
 
 ---
 
+## 🎓 Lessons Learned: Agentless Mode (CHEF-23408) Cross-Repo Development
+
+This epic spans two repos — `chef-test-kitchen-enterprise` (TKE core, this
+repo) and `chef/kitchen-agentless` (KCAI, the plugin). Extensive
+end-to-end debugging sessions against real Docker, EC2-ephemeral, and
+real-mode targets surfaced patterns worth capturing for future work in either
+repo. See also `AGENTS.md`, `.github/instructions/bug-fix-workflow.instructions.md`,
+and `.github/instructions/agentless-config-extension.instructions.md` for
+fuller detail.
+
+### TKE core stays generic — agentless logic lives in KCAI
+
+TKE core's role for this epic is to expose **generic, agentless-unaware
+extension points** (`driver.source_info` hook in `kitchen list`,
+`--driver-option` passthrough in `kitchen destroy`) that any driver could use
+— not to know anything about "agentless" as a concept. If a change request
+sounds agentless-specific, it almost certainly belongs in KCAI, not here.
+Both TKE-core stories for this epic (CHEF-27348, CHEF-36826) are complete;
+new work should default to the KCAI repo unless a genuinely new generic hook
+is required.
+
+### The three target-credential styles a plugin like KCAI must support
+
+When building or extending a driver/provisioner/verifier plugin that
+targets ephemeral or static remote hosts, credential/endpoint resolution
+must correctly support (without one clobbering another):
+
+1. **Real/static-mode hosts** — credentials from a credential-map-file or
+   per-node config, gated to only apply in real/static mode.
+2. **Ephemeral drivers that self-generate credentials** (e.g. `kitchen-docker`
+   generates its own SSH keypair into driver state) — must be read from
+   **driver state**, not a stale config file.
+3. **Ephemeral drivers using a pre-existing named resource** (e.g.
+   `kitchen-ec2` with a named AWS keypair) — these generate **no** dynamic
+   state credentials; the only source is Test Kitchen's own standard
+   `transport:` block, resolved via `instance.transport`. Forgetting this
+   fallback is a common bug (username silently defaults to `"root"`, no key
+   is found, and credential provisioning is silently skipped).
+
+**Correct fallback order**: credential-map-file (real-mode only) →
+plugin-specific per-node transport config → driver state → `instance.transport`
+→ hardcoded default. Driver state must be checked *before*
+`instance.transport`, because TK's own SSH transport defaults `username` to
+`"root"` (always truthy), which would otherwise always shadow a driver's real
+dynamically-assigned username.
+
+### Provisioner/verifier logic duplication is a recurring bug source
+
+When a plugin ships both a provisioner and a verifier (e.g. chef-client +
+InSpec, both operating in a "target mode" against the same remote host), the
+credential/endpoint resolution logic is easy to implement twice and let
+drift out of sync. A bug fix applied to one is easily forgotten in the
+other. When fixing this class of bug, always check and update both, and add
+regression tests to both spec files.
+
+### Environment gotchas that look like code bugs but aren't
+
+- **`KITCHEN_YAML` env var** overrides which kitchen config file is used —
+  if an error references a host/driver that doesn't match the visible
+  `kitchen.yml`, check this env var first.
+- **Stale `.kitchen/*.yml` state files** persist a previous run's
+  server-id/hostname when a user switches kitchen configs without running
+  `kitchen destroy` first — produces confusing "wrong host"/"credentials not
+  found" errors. Compare state-file mtimes/content against the active config
+  before assuming a regression.
+- **InSpec/Chef license and install-strategy failures** (interactive license
+  prompts, `dpkg` permission errors, missing `license_acceptance` gem) are
+  almost always source-node environment issues, not plugin code bugs — but
+  the fix (e.g. `CHEF_LICENSE=accept` env var, running installers as root)
+  needs to be applied consistently across every command invocation path
+  (chef-client *and* InSpec), not just one.
+
+### Commit-and-push-for-review vs. PR-and-merge
+
+Many sessions in this epic push directly to a shared integration branch
+(e.g. `agentless-dev-latest`) with DCO signoff so the user can review real
+end-to-end test output before a PR is even opened. **Do not run
+`gh pr create` unless the user has explicitly asked for a PR** — confirm
+first if it wasn't part of the request.
+
+---
+
 ## 📝 Summary
 
 This copilot-instructions.md provides comprehensive guidance for contributing to Chef Test Kitchen Enterprise. Key requirements:

--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -1,0 +1,9 @@
+steps:
+  - name: Install Ruby dependencies
+    run: bundle install
+
+  - name: Verify unit tests run
+    run: bundle exec rake unit || true
+
+  - name: Verify linter
+    run: bundle exec cookstyle --chefstyle || true

--- a/.github/instructions/agentless-config-extension.instructions.md
+++ b/.github/instructions/agentless-config-extension.instructions.md
@@ -1,0 +1,109 @@
+---
+applyTo: "lib/kitchen/command/list.rb,lib/kitchen/command/destroy.rb,lib/kitchen/provisioner/base.rb"
+---
+
+# Extending Agentless Support in TKE Core vs. KCAI
+
+## Architecture note (post CHEF-27348 / CHEF-23408 rewrite)
+
+Earlier generations of this epic (Waves 1–14) put agentless-specific config
+parsing, credential resolution, and remote-node modeling directly into TKE
+core (`lib/kitchen/agentless/`, `lib/kitchen/agentless_context.rb`,
+`lib/kitchen/remote_node.rb`, etc). **That code has been deleted
+(CHEF-27348).** Do not resurrect this pattern.
+
+The current architecture is:
+
+| Repo | Owns |
+|------|------|
+| `chef-test-kitchen-enterprise` (TKE core, this repo) | Generic driver/provisioner/verifier extension points only. No knowledge of "agentless" as a concept. |
+| `chef/kitchen-agentless` (KCAI) | Everything agentless-specific: the `agentless:` config block, `AgentlessContext`, `RemoteNode`, credential resolution, the `Kitchen::Driver::Agentless`, `Kitchen::Provisioner::ChefInfraAgentless`, and `Kitchen::Verifier::InspecAgentless` classes. |
+
+If you're asked to add a new field to the `agentless:` block in `kitchen.yml`,
+**that work belongs in KCAI**, not here. See the equivalent
+`agentless-config-extension.instructions.md` in the KCAI repo (if present) —
+or just follow the pattern below there.
+
+## What TKE core actually owns for this epic
+
+TKE core changes for CHEF-23408 are strictly limited to generic hooks any
+driver could use — they must contain zero agentless-specific logic:
+
+| File | What it exposes | Story |
+|------|------------------|-------|
+| `lib/kitchen/command/list.rb` | Generic `driver.source_info` hook — if a driver responds to `#source_info`, an extra section is rendered above the instances table (works for *any* driver, not just agentless) | CHEF-36826 (done) |
+| `lib/kitchen/command/destroy.rb` | Generic `--driver-option key=value` passthrough so any plugin can receive destroy-time flags | CHEF-36826 (done) |
+| `lib/kitchen/provisioner/base.rb` | No agentless-specific config — `#agentless_mode?` and `default_config :agentless` were removed here (CHEF-27348, done) | CHEF-27348 (done) |
+
+If a change request for this epic touches any file other than the three
+above, stop and confirm it isn't actually KCAI-plugin work that was
+misdirected at this repo.
+
+## Adding a new generic driver hook (the TKE-core pattern to follow)
+
+Example: adding a new hook so any driver can contribute a status line to
+`kitchen list`.
+
+1. In the relevant `lib/kitchen/command/*.rb`, check `respond_to?` on the
+   driver/provisioner/verifier rather than hardcoding a class name:
+
+```ruby
+# lib/kitchen/command/list.rb — generic, agentless-unaware
+def print_table(instances)
+  source = instances.first&.driver&.respond_to?(:source_info) &&
+           instances.first.driver.source_info
+  print_source_section(source) if source
+  # ... existing instances table rendering ...
+end
+```
+
+2. Document the expected return shape (e.g. a Hash with specific keys) in a
+   code comment, since TKE core has no interface/protocol enforcement beyond
+   `respond_to?`.
+3. Add a spec in `spec/kitchen/command/*_spec.rb` using a stub/double that
+   responds to the new method — do not depend on any real plugin.
+4. Add a regression test for the case where the driver does **not** respond
+   to the hook (must degrade gracefully, no `NoMethodError`).
+
+## Extending the `agentless:` config block itself (KCAI repo, for reference)
+
+Even though this work happens in KCAI, it's useful context when reviewing
+cross-repo changes. Key KCAI files:
+
+| File | Role |
+|------|------|
+| `lib/kitchen/driver/agentless.rb` | Parses `agentless:` config, manages source-node lifecycle |
+| `lib/kitchen/provisioner/chef_infra_agentless.rb` | chef-client target-mode invocation, credential/endpoint resolution |
+| `lib/kitchen/verifier/inspec_agentless.rb` | InSpec target-mode invocation — **duplicates**, not inherits, the provisioner's credential/endpoint resolution |
+
+When adding a new `agentless:` field (e.g. a new `remote_nodes[].transport`
+option), remember:
+- Both the provisioner and verifier likely need the change — they are
+  separate classes with parallel logic (see
+  `bug-fix-workflow.instructions.md`'s note on this being a recurring bug
+  source).
+- Consider all **three target-provisioning styles** (real-mode static host,
+  ephemeral Docker, ephemeral EC2 with a named keypair) when adding to the
+  credential-resolution chain — see `bug-fix-workflow.instructions.md` for
+  the full priority order and rationale.
+- Add regression tests for both real-mode and ephemeral-mode behavior; a
+  test suite that only covers one mode will miss the class of bugs this repo
+  has repeatedly hit (stale credential-map-file hijacking, missing driver
+  state fallback, missing `instance.transport` fallback).
+
+## Running TKE core tests
+
+```bash
+cd /path/to/chef-test-kitchen-enterprise
+bundle exec rake unit                            # Minitest unit suite
+bundle exec rake features                        # Cucumber integration suite
+bundle exec cookstyle --chefstyle lib/ spec/     # lint
+```
+
+## Critical rules
+
+- TKE core must have **zero** references to "agentless" as a concept —
+  only generic `respond_to?`-based extension points.
+- Never call `instance.state_file` from outside `Instance` — it's private;
+  use the `state` hash passed into lifecycle methods.
+- Do not modify `lib/kitchen/version.rb` or `CHANGELOG.md` — managed by Expeditor.

--- a/.github/instructions/bug-fix-workflow.instructions.md
+++ b/.github/instructions/bug-fix-workflow.instructions.md
@@ -1,0 +1,190 @@
+---
+applyTo: "**/*"
+---
+
+# Bug Fix Workflow for Agentless Mode (KCAI + TKE core)
+
+## How to read a failure
+
+- `.kitchen/logs/kitchen.log` — top-level command log.
+- `.kitchen/logs/<instance>.log` — per-instance log, usually has the real stack trace.
+- **Check `KITCHEN_YAML` first.** If the error mentions a host/sub-driver that
+  doesn't match the `kitchen.yml` you're looking at, the user is very likely
+  running with `KITCHEN_YAML=some-other.yml kitchen ...`. Always ask or check
+  the shell history/env before assuming a code regression.
+- **Check for stale `.kitchen/*.yml` state files.** If a user switches between
+  different kitchen configs (e.g. Docker-ephemeral vs. `kitchen.ec2.yml`)
+  without running `kitchen destroy` first, `.kitchen/<instance>.yml` and
+  `.kitchen/<source>.yml` retain the *previous* config's driver/server-id/host,
+  producing confusing "wrong host" or "credentials file not found" errors that
+  look like code bugs but are actually just leftover local state. Compare file
+  mtimes/content against the currently active kitchen.yml before debugging further.
+  Fix: `rm .kitchen/<instance>.yml .kitchen/<source>.yml` and re-run `kitchen create`.
+
+## Credential / endpoint resolution (the most common source of bugs)
+
+KCAI must support **three distinct target-provisioning styles**, and the
+resolution chain in both `chef_infra_agentless.rb` (provisioner) and
+`inspec_agentless.rb` (verifier) must handle all three without one silently
+clobbering another:
+
+1. **Real-mode static hosts** — credentials come from the credential-map-file
+   (`credentials.yml`, keyed by instance name) or
+   `agentless.remote_nodes[name].transport`. Only consult these when
+   `real_mode?` is true — checking them unconditionally lets a **stale
+   credential-map-file entry hijack an ephemeral target's real, valid
+   credentials** (this exact bug shipped once — see commit `4a5a9b0`/`5b40e44`).
+2. **Ephemeral Docker targets** — `kitchen-docker` self-generates an SSH
+   keypair (`.kitchen/docker_id_rsa`) and sets `state[:ssh_key]`, defaulting
+   username to `"kitchen"` — but it **never sets `state[:username]`
+   itself**. Credentials live in **driver state**.
+3. **Ephemeral EC2 (or any driver using a pre-existing named keypair)** — the
+   sub-driver does **not** generate dynamic credentials in state at all. The
+   user configures username/ssh_key via kitchen.yml's **standard Test Kitchen
+   `transport:` block** (top-level/suite/platform), resolved by TK into
+   `instance.transport`. If this fallback is missing, username silently
+   defaults to `"root"` and no key/password is found — target-credential
+   provisioning is skipped entirely and chef-client/InSpec fail looking for a
+   credentials file that was never written.
+
+**Correct resolution priority** (for username/ssh_key/password, in each of
+`resolve_target_username`/`resolve_target_ssh_key`/`resolve_target_password`):
+
+```
+credential-map-file (real_mode? only)
+  → agentless.remote_nodes[name].transport
+  → top-level node config
+  → driver state                                    (Docker's dynamic creds)
+  → instance's own resolved transport config          (instance.transport.diagnose)
+  → hardcoded default ("root" / nil)
+```
+
+**Driver state must be checked before `instance.transport`.** TK's own
+`Kitchen::Transport::Ssh` sets `default_config :username, "root"`, so
+`instance.transport.diagnose[:username]` is **always truthy** even when the
+user never configured it explicitly. If checked before driver state, it would
+always shadow Docker's real, dynamically-assigned username. `ssh_key`/`password`
+don't have this problem since their TK transport defaults are `nil` — but keep
+the same ordering for consistency and to support all three styles uniformly.
+
+`instance.transport.diagnose` returns a Hash of fully-resolved config
+(symbol-keyed); `ssh_key` may come back as a single path or an `Array` —
+normalize with `Array(...).first`.
+
+## Common failure patterns and fixes
+
+### `Net::SSH::AuthenticationFailed` / wrong username against an ephemeral Docker target
+
+Check `credential_file_ssh_entry` isn't being consulted unconditionally — gate
+it to `real_mode?` only. See "Credential / endpoint resolution" above.
+
+### `Your SSH Agent has no keys added, and you have not specified a password or a key file` (InSpec verify)
+
+The verifier has its **own, separate** copy of the credential-resolution logic
+(`inspec_agentless.rb` does not inherit from the provisioner). A fix applied
+to the provisioner's `resolve_target_*` methods must be mirrored in the
+verifier's — they are easy to forget since they look similar but are not DRY'd
+up. Also check `decorate_credential_manager` builds the InSpec `--user`
+`--password` `--key_files` CLI args from `resolve_target_username`/
+`resolve_target_ssh_key`/`resolve_target_password`, not directly from
+`resolved_credentials_for` (which is real-mode-only and returns nothing for
+ephemeral targets with no credential-map-file entry).
+
+### `ECONNREFUSED` connecting to `127.0.0.1:<port>` (verify against a Docker target)
+
+The verifier's `resolve_target_endpoint` is missing the Docker-internal-bridge
+-IP resolution the provisioner already has. From *inside* the agentless-source
+container, the host-mapped port (`localhost:<port>`) is unreachable — you must
+resolve the container's internal IP via `docker inspect` (see
+`docker_internal_ip` in `chef_infra_agentless.rb`) whenever `state[:container_id]`
+is present, and port back to plain `22` instead of the host-mapped port.
+
+### `ArgumentError: Credentials file specified for target mode does not exist: '~/.chef/target_credentials'`
+
+Target-credential provisioning was silently skipped because username/ssh_key
+resolution fell through to nothing usable (commonly: an ephemeral EC2 target
+whose only credential source is the standard `transport:` block — see
+"Credential / endpoint resolution" above; the `instance_transport_config`
+fallback fixes this specific case).
+
+### `cannot load such file -- license_acceptance/acceptor`
+
+The `license_acceptance` gem isn't available on the *source* node where
+chef-client/InSpec actually runs. This is an environment/install issue on the
+agentless-source, not a KCAI code bug — check the Chef Infra Client / InSpec
+install strategy and version on the source node.
+
+### InSpec install fails with `dpkg: error: requested operation requires superuser privilege`
+
+The InSpec omnitruck installer needs to run as root on the source node.
+Check `install_strategy` / the install command is prefixed with `sudo` (or run
+as root) when installing a specific/pinned InSpec version rather than relying
+on a pre-baked image.
+
+### InSpec stuck at an interactive "License ID Validation" prompt
+
+InSpec (Chef License) needs `CHEF_LICENSE=accept` (and `CHEF_LICENSE_KEY=...`
+if a commercial/free-tier key is configured) in the environment for **every**
+`inspec exec` invocation, not just chef-client. Check both the
+provisioner's and verifier's command-building code set this env var
+consistently — a mismatch (one sets it, the other doesn't) causes exactly this
+symptom on `kitchen verify` after `kitchen converge` succeeds.
+
+### `NoMethodError` / `undefined method` calling a private TKE method
+
+Common culprit: calling `instance.state_file` directly. Use the `state` hash
+passed into lifecycle methods instead.
+```ruby
+# WRONG:
+instance.state_file.read["some_key"]
+# CORRECT:
+state[:some_key]
+```
+
+### Shell operators not working (`|`, `>`, `&&`) when executing on the source/target
+
+Docker exec / Train's SSH backend calls the command directly — **no shell**.
+Wrap multi-command strings in `sh -c '...'`:
+```ruby
+# WRONG:
+conn.execute("echo #{encoded} | base64 -d > /root/.ssh/key")
+# CORRECT:
+conn.execute("sh -c 'echo #{encoded} | base64 -d > /root/.ssh/key'")
+```
+
+### `train-docker gem not found` / `Docker URI not supported`
+
+`docker://container-name` URIs require the `train-docker` gem, which is not
+bundled by default. Prefer SSH transport (`ssh://user@ip:22`) for
+container-mode targets instead of a raw `docker://` URI.
+
+## Debug commands
+
+```bash
+# See what's on the agentless-source container/host
+docker exec <source-container-name> ls /tmp/kitchen-sandbox/
+docker exec <source-container-name> cat ~/.chef/target_credentials
+
+# Confirm which kitchen.yml is actually active
+echo $KITCHEN_YAML
+ls -la .kitchen/*.yml   # check mtimes against the active config
+
+# Full kitchen debug
+bundle exec kitchen --log-level debug converge 2>&1 | tee /tmp/kitchen-debug.log
+```
+
+## After fixing
+
+Fix both the provisioner (`chef_infra_agentless.rb`) **and** the verifier
+(`inspec_agentless.rb`) if the bug is in credential/endpoint resolution — they
+are separate classes with duplicated logic, not shared via inheritance.
+
+```bash
+bundle exec rake unit                            # must be 0 failures
+bundle exec cookstyle --chefstyle lib/ spec/     # must be 0 new offenses
+bundle exec kitchen destroy && bundle exec kitchen converge && bundle exec kitchen verify  # end-to-end
+```
+
+Test against **all three provisioning styles** when the fix touches
+credential/endpoint resolution: real-mode static host, ephemeral Docker
+target, ephemeral EC2 target (named keypair via standard `transport:` block).

--- a/.github/instructions/pr-workflow.instructions.md
+++ b/.github/instructions/pr-workflow.instructions.md
@@ -1,0 +1,135 @@
+---
+applyTo: "**/*"
+---
+
+# PR and Git Workflow for Agentless Mode Stories
+
+## Repos involved
+
+This epic spans **two repositories** — always be clear which one you're in
+before running git/gh commands:
+
+| Repo | Role |
+|------|------|
+| `chef/chef-test-kitchen-enterprise` (this repo, "TKE core") | Plugin host: CLI, instance lifecycle, generic driver/provisioner/verifier extension points |
+| `chef/kitchen-agentless` ("KCAI") | The actual agentless driver/provisioner/verifier plugin — almost all feature work lives here |
+
+TKE core changes for this epic should be **strictly minimal** (see AGENTS.md
+"Permitted TKE Core Changes"). If a change is agentless-specific, it almost
+certainly belongs in KCAI, not here.
+
+## Branch naming
+
+| Story type | Branch format |
+|-----------|---------------|
+| Agentless epic story | `CHEF-XXXXX` or `CHEF-XXXXX-<short-description>` |
+| Bug fix | `CHEF-XXXXX-fix-<what>` |
+| Multi-repo story | Same branch name in both repos |
+
+## Target branch
+
+- **TKE core**: all feature branches are cut from `agentless-dev-latest`, and all PRs target `agentless-dev-latest` — **never `main` directly**.
+- **KCAI**: all feature branches are cut from `agentless-dev-latest`, and all PRs target `agentless-dev-latest`.
+
+```bash
+git fetch origin
+git checkout agentless-dev-latest
+git pull origin agentless-dev-latest
+git checkout -b CHEF-XXXXX
+```
+
+## Commit format (DCO required)
+
+```bash
+git commit --signoff -m "CHEF-XXXXX: <short description>
+
+- What was changed
+- Why it was changed
+- Any notable decisions"
+```
+
+DCO signoff (`--signoff` / `-s`) is **mandatory**. Missing signoff fails CI.
+If you forget: `git commit --amend --signoff --no-edit`.
+
+For multi-line commit messages, write the message to a temp file
+(`/tmp/commit_msg.txt`) and commit with `git commit --signoff -F /tmp/commit_msg.txt`,
+then delete the temp file. This avoids shell-escaping issues with
+apostrophes/backticks in commit bodies.
+
+## Ask before opening a PR
+
+Unless the user has explicitly asked for a PR, treat implementation work as
+**commit-and-push for review, not PR-and-merge**. Many sessions in this repo
+push directly to a feature/integration branch (e.g. `agentless-dev-latest`)
+so the user can review real end-to-end test output (`kitchen create` /
+`converge` / `verify` against live targets) before a PR is even opened.
+**Always confirm with the user before running `gh pr create`** if it wasn't
+explicitly requested — do not assume a commit should immediately become a PR.
+
+## PR creation (once approved)
+
+```bash
+gh pr create \
+  --base agentless-dev-latest \
+  --title "CHEF-XXXXX: description" \
+  --label "ai-assisted" \
+  --body "..."
+```
+
+**Required labels**: `ai-assisted` must always be present on AI-assisted PRs.
+
+## PR description template
+
+```html
+<h2>Summary</h2>
+<p>What this PR implements.</p>
+
+<h2>Jira Story</h2>
+<p><a href="https://progresssoftware.atlassian.net/browse/CHEF-XXXXX">CHEF-XXXXX</a></p>
+
+<h2>Changes</h2>
+<ul>
+  <li><code>lib/kitchen/provisioner/chef_infra_agentless.rb</code> — what changed</li>
+  <li><code>spec/kitchen/provisioner/chef_infra_agentless_spec.rb</code> — tests added</li>
+</ul>
+
+<h2>Testing</h2>
+<ul>
+  <li>Unit tests: X new tests, Y% coverage</li>
+  <li>Lint: 0 offenses</li>
+  <li>End-to-end: kitchen create/converge/verify/destroy verified against a real target</li>
+</ul>
+```
+
+## Multi-repo PRs
+
+When a story touches both `chef-test-kitchen-enterprise` (TKE core) and
+`kitchen-agentless` (KCAI), create PRs in both repos with:
+- Same branch name
+- Cross-linked PR descriptions
+- Both targeting `agentless-dev-latest`
+
+## Expeditor labels
+
+| Change type | Labels to add |
+|-------------|--------------|
+| New feature | `enhancement`, `Expeditor: Bump Version Minor` |
+| Bug fix | `bug` |
+| Test/docs only | `Expeditor: Skip Version Bump` |
+| Breaking change | `Expeditor: Bump Version Major` |
+| Documentation only | `documentation`, `Expeditor: Skip All` |
+
+## Pre-PR checklist
+
+```bash
+bundle exec rake unit                           # 0 failures
+bundle exec cookstyle --chefstyle lib/ spec/    # 0 offenses (new offenses only —
+                                                 # don't fix unrelated pre-existing ones)
+bundle exec kitchen destroy && bundle exec kitchen converge && bundle exec kitchen verify
+```
+
+All of the above must be green before creating a PR. For KCAI end-to-end
+checks, test against **all three target-provisioning styles** if the change
+touches credential/endpoint resolution (see
+`agentless-config-extension.instructions.md`): real-mode static host,
+ephemeral Docker target, ephemeral EC2 target.

--- a/.github/skills/create-kitchen-plugin/SKILL.md
+++ b/.github/skills/create-kitchen-plugin/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: create-kitchen-plugin
+description: 'Create a new Test Kitchen plugin or plugin scaffold. Use when creating a Kitchen driver plugin, a Kitchen provisioner plugin, a new kitchen-* repository, or when deciding whether provisioner work belongs in kitchen-chef-enterprise versus a separate premium plugin repo. Includes repo naming, gem naming, GitHub workflow, and Expeditor setup rules.'
+argument-hint: 'Describe the plugin type, plugin name, premium status if provisioner, and any target repo constraints.'
+user-invocable: true
+---
+
+# Create Kitchen Plugin
+
+## What This Skill Does
+
+This skill creates or scaffolds a new Test Kitchen plugin using the Chef Test Kitchen conventions in this workspace.
+
+It handles three cases:
+
+1. Driver plugin: create a new repository named `kitchen-<plugin-name>`.
+2. Non-premium provisioner plugin: extend `kitchen-chef-enterprise` instead of creating a new repository.
+3. Premium provisioner plugin: create a separate plugin repository and scaffold it to match the enterprise plugin layout.
+
+The resulting repo, gem name, module layout, CI workflows, and Expeditor config must match the established patterns used by Chef Test Kitchen repositories, especially `chef/kitchen-chef-enterprise` for plugin-repo automation and release plumbing, and `chef/kitchen-agentless` (KCAI) as a real-world example of a premium provisioner+verifier+driver plugin built against this framework.
+
+## When To Use
+
+Use this skill when the request includes any of these intents or keywords:
+
+- Create a new Kitchen plugin
+- Scaffold a Kitchen driver
+- Scaffold a Kitchen provisioner
+- Create a `kitchen-...` repository
+- Add a premium Kitchen provisioner plugin
+- Add GitHub workflows or Expeditor config for a new Kitchen plugin repo
+
+Do not use this skill for small edits inside an existing plugin unless the request also includes repo bootstrapping or plugin creation.
+
+## Inputs To Collect
+
+Before writing files, determine these inputs from the user request or ask only for the missing ones:
+
+- Plugin type: `driver` or `provisioner`
+- Plugin name: normalized kebab-case suffix used in repo and gem naming
+- Premium status for provisioners: `premium` or `non-premium`
+- Target location: existing repo or new repo
+- Whether the user wants full repo scaffolding or only the plugin implementation slice
+- If the plugin has a paired verifier (e.g. an InSpec-based verifier alongside a provisioner) — premium provisioner plugins often ship both, as separate classes rather than shared inheritance (see "Provisioner/Verifier pairing" below).
+
+## Decision Flow
+
+### Driver Plugin
+
+If the plugin type is `driver`:
+
+1. Create a new repository named `kitchen-<plugin-name>`.
+2. Set the gem name to `kitchen-<plugin-name>`.
+3. Align repository structure and packaging conventions with `chef-test-kitchen-enterprise` and existing Kitchen plugin repos.
+4. Add GitHub workflows and `.expeditor/` configuration that match `chef/kitchen-chef-enterprise`.
+
+### Provisioner Plugin
+
+If the plugin type is `provisioner`:
+
+1. Determine whether it is premium.
+2. If it is non-premium, do not create a new repo. Add the implementation to `kitchen-chef-enterprise`.
+3. If it is premium, create a separate plugin repository and scaffold it with the same workflow and Expeditor baseline used by `chef/kitchen-chef-enterprise`.
+
+## Procedure
+
+### 1. Confirm the Controlling Case
+
+Reduce the request to one of these mutually exclusive outcomes:
+
+- New driver repo
+- Existing non-premium provisioner work in `kitchen-chef-enterprise`
+- New premium provisioner repo
+
+If the request does not clearly state whether a provisioner is premium, stop and ask that question before editing.
+
+### 2. Inspect the Baseline Before Editing
+
+Read only the minimum files needed to match the existing conventions.
+
+For all cases:
+
+- Review [AGENTS.md](../../../AGENTS.md) for Kitchen-specific conventions in this workspace.
+- Inspect the relevant gemspec, module layout, and test structure in the target repo.
+
+For new repos:
+
+- Inspect the GitHub workflow files used by `chef/kitchen-chef-enterprise`.
+- Inspect `.expeditor/config.yml` and `.expeditor/verify.pipeline.yml` in `chef/kitchen-chef-enterprise`.
+- Mirror those files closely unless the user requests a deliberate deviation.
+
+### 3. Create the Repository Skeleton
+
+For a new plugin repo, create the minimum baseline expected for a Kitchen plugin repository:
+
+- `README.md`
+- `LICENSE`
+- `NOTICE` if the source pattern uses it
+- `Gemfile`
+- `<repo-name>.gemspec`
+- `Rakefile`
+- `.github/workflows/`
+- `.expeditor/`
+- `lib/`
+- `spec/`
+
+Use the plugin type to shape the Ruby entrypoints:
+
+- Driver plugin: `lib/kitchen/driver/<plugin_name>.rb`
+- Provisioner plugin: `lib/kitchen/provisioner/<plugin_name>.rb`
+- Paired verifier (if applicable): `lib/kitchen/verifier/<plugin_name>.rb`
+
+Also add the top-level entry file under `lib/` that requires the plugin implementation and follows the established naming pattern.
+
+### 4. Apply Naming Rules
+
+Use consistent names across all surfaces.
+
+- Repository: `kitchen-<plugin-name>` for all new driver repos
+- Gem: `kitchen-<plugin-name>` unless the target repo already establishes a different convention
+- Main Ruby file names: snake_case version of the plugin name
+- Ruby module names: CamelCase version of the plugin name nested under the correct Kitchen namespace
+
+For provisioners that remain inside `kitchen-chef-enterprise`, preserve that repo's existing gem and module structure instead of forcing a new `kitchen-...` gem.
+
+### 5. Add CI And Release Plumbing
+
+For any new repository, copy the workflow and release-management baseline from `chef/kitchen-chef-enterprise`.
+
+At minimum, create equivalents of the standard files present there:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/lint.yml`
+- `.github/workflows/integration.yml`
+- `.github/workflows/allchecks.yml`
+- `.expeditor/config.yml`
+- `.expeditor/verify.pipeline.yml`
+
+If the baseline repo includes helper scripts under `.expeditor/`, copy the same pattern and update only repo-specific names or commands.
+
+Do not invent a different CI layout when an existing enterprise plugin baseline already exists.
+
+### 6. Implement The Plugin Slice
+
+Create the smallest useful plugin scaffold that matches Test Kitchen plugin conventions.
+
+For drivers:
+
+- Add the plugin class under `Kitchen::Driver`
+- Register the correct plugin API version and plugin version pattern used by the baseline repo
+- Add a minimal configuration surface and lifecycle stubs
+
+For provisioners:
+
+- Add the plugin class under `Kitchen::Provisioner`
+- Follow the existing provisioner base class pattern in the target repo
+- Add only the minimal config and command construction needed for the requested plugin scaffold
+
+### 7. Provisioner/Verifier Pairing (learned from KCAI)
+
+If the plugin ships a provisioner and a verifier together (common for
+premium plugins that run both configuration-management and compliance
+tooling against the same target), do **not** assume shared logic can live in
+a common base class purely by inheritance if the two classes have genuinely
+different base types (`Kitchen::Provisioner::Base` vs.
+`Kitchen::Verifier::Base`). In practice this has meant:
+
+- Credential/endpoint resolution logic (username, ssh_key, password,
+  target host/port) is easy to implement twice, subtly differently, and let
+  them drift out of sync — a bug fixed in the provisioner's resolution chain
+  may not get mirrored into the verifier's, and vice versa. If duplicating
+  logic across a provisioner and verifier, either:
+  - extract a small shared module (e.g. `Kitchen::Agentless::CredentialResolution`)
+    included into both, or
+  - explicitly flag in code comments/tests that the two copies must be kept
+    in sync, and add a regression test in **both** spec files whenever either
+    is changed.
+- Any command/state built for one (e.g. Docker-internal-bridge-IP resolution,
+  license/env-var handling) usually needs the equivalent in the other.
+
+### 8. Add Tests With Matching Structure
+
+Mirror the spec layout used by the target repo.
+
+- New repo: create spec files that match the plugin file layout
+- Existing `kitchen-chef-enterprise` work: place specs alongside the existing provisioner specs in that repo
+
+Cover at least:
+
+- Plugin loads successfully
+- Default config behavior
+- One representative positive path
+- One representative validation or error path
+- If the plugin supports multiple target-provisioning/credential styles (e.g. static/real-mode hosts vs. ephemeral drivers with dynamically-generated credentials vs. ephemeral drivers using a pre-existing named keypair), add a regression test per style — bugs in this area tend to be style-specific and easy to miss with only one style under test.
+
+### 9. Validate Before Stopping
+
+Run the narrowest useful checks for the touched repo.
+
+- Unit tests for the new plugin spec files
+- Lint or style checks used by the target repo
+- Any narrow load-path or require check for the new gem entrypoint
+
+For new repos, confirm these are consistent before finishing:
+
+- Repo name matches gem name where required
+- Main require paths match file names
+- Workflow filenames exist and reference the new repo correctly
+- Expeditor config is present and internally consistent
+
+## Quality Bar
+
+The work is only complete when all of the following are true:
+
+- The plugin is routed to the correct place based on plugin type and premium status.
+- New repos use `kitchen-<plugin-name>` naming where required by this workflow.
+- Non-premium provisioners are kept in `kitchen-chef-enterprise`.
+- New repos include GitHub workflow files and Expeditor config matching the `chef/kitchen-chef-enterprise` baseline.
+- Ruby file layout, gem naming, and module naming are internally consistent.
+- At least one focused validation step has been run.
+- If a provisioner/verifier pair was created, credential/endpoint resolution behavior (and its tests) exist for every target-provisioning style the plugin claims to support.
+
+## Ambiguities To Resolve Early
+
+Ask a focused question if any of these remain unclear:
+
+- For a provisioner, is this premium or non-premium?
+- For a premium provisioner repo, should the repo name still be `kitchen-<plugin-name>` or should it follow a `kitchen-chef-...` convention?
+- Does the user want full repository scaffolding or only the plugin implementation inside an existing repo?
+- Which existing repo should be treated as the source of truth if `chef-test-kitchen-enterprise` and `kitchen-chef-enterprise` differ?
+- Does the plugin need a paired verifier, and if so, should shared credential/endpoint logic be extracted into a common module rather than duplicated?
+
+## Example Prompts
+
+- `/create-kitchen-plugin Create a new Kitchen driver plugin named ec2spot as a new repo.`
+- `/create-kitchen-plugin Scaffold a premium Kitchen provisioner plugin named chef-orchestrator in a separate repo.`
+- `/create-kitchen-plugin Add a non-premium provisioner named chef-local into kitchen-chef-enterprise and include tests.`
+- `/create-kitchen-plugin Add a paired InSpec-based verifier to an existing premium provisioner plugin, sharing credential resolution logic with the provisioner.`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,27 +9,31 @@
 
 `chef-test-kitchen-enterprise` is the **enterprise fork of Test Kitchen** — a Ruby tool for developing and testing infrastructure code (Chef cookbooks) on isolated target platforms. It is the core orchestration engine: CLI, instance lifecycle, driver/provisioner/verifier plugin loading, state management, and output formatting.
 
-This repo is a **plugin host**. Most feature work for CHEF-23408 lives in `chef/kitchen-chef-infra-agentless`, not here.
+This repo is a **plugin host**. Most feature work for CHEF-23408 lives in `chef/kitchen-agentless`, not here.
 
 ---
 
 ## Epic Context: CHEF-23408 — Agentless Mode
 
-TKE core changes for this epic are **strictly minimal**. The agentless plugin (`kitchen-chef-infra-agentless`) provides a driver, provisioner, and verifier. TKE core only needs generic extension points that any driver can use — it must not contain agentless-specific logic.
+TKE core changes for this epic are **strictly minimal**. The agentless plugin (`kitchen-agentless`, "KCAI") provides a driver, provisioner, and verifier. TKE core only needs generic extension points that any driver can use — it must not contain agentless-specific logic.
+
+**Status: both TKE-core stories below are complete.** Almost all active/ongoing agentless work now happens in `chef/kitchen-agentless`, not here. Only touch this repo again for this epic if a *new* generic extension point is needed (i.e. something no existing driver/provisioner/verifier hook can express).
 
 ### Permitted TKE Core Changes (entire epic)
 
-| File | What Changes | Story |
-|------|-------------|-------|
-| `lib/kitchen/command/list.rb` | Add generic `driver.source_info` hook — if driver responds to `#source_info`, render an extra section above the instances table | CHEF-36826 |
-| `lib/kitchen/command/destroy.rb` | Add generic `--driver-option` passthrough so plugins can receive destroy-time flags | CHEF-36826 |
-| `lib/kitchen/agentless/` (delete entire dir) | Remove all Waves 1–14 agentless code | CHEF-27348 |
-| `lib/kitchen/provisioner/base.rb` | Remove `#agentless_mode?` method + `default_config :agentless` | CHEF-27348 |
+| File | What Changes | Story | Status |
+|------|-------------|-------|--------|
+| `lib/kitchen/command/list.rb` | Add generic `driver.source_info` hook — if driver responds to `#source_info`, render an extra section above the instances table | CHEF-36826 | ✅ Done |
+| `lib/kitchen/command/destroy.rb` | Add generic `--driver-option` passthrough so plugins can receive destroy-time flags | CHEF-36826 | ✅ Done |
+| `lib/kitchen/agentless/` (delete entire dir) | Remove all Waves 1–14 agentless code | CHEF-27348 | ✅ Done |
+| `lib/kitchen/provisioner/base.rb` | Remove `#agentless_mode?` method + `default_config :agentless` | CHEF-27348 | ✅ Done |
 
-> ⛔ **No other files in this repo should be modified for CHEF-23408.** If you find yourself editing anything else, stop and re-read the architecture doc.
+> ⛔ **No other files in this repo should be modified for CHEF-23408.** If you find yourself editing anything else, stop and re-read the architecture doc — it's almost certainly KCAI plugin work, not TKE core work.
 
 Full architecture: `CHEF-23408-NEW-ARCHITECTURE.md` in this repo.
 Full wave plan: `CHEF-23408-WAVE-PLAN.md` in this repo.
+Reusable extension guidance: `.github/instructions/agentless-config-extension.instructions.md`.
+Common bug patterns and fixes seen across many debugging sessions: `.github/instructions/bug-fix-workflow.instructions.md`.
 
 ---
 
@@ -208,6 +212,38 @@ bundle exec rake quality
 - **License header:** Apache 2.0 on all new `.rb` files
 
 ---
+
+## Lessons Learned From KCAI End-to-End Debugging
+
+Extensive real-target debugging sessions (Docker ephemeral, EC2 ephemeral,
+and real-mode static hosts) surfaced a recurring class of issues, almost all
+in KCAI rather than TKE core. Captured here so future sessions in either repo
+don't have to rediscover them:
+
+- **Three distinct target-credential styles must all be supported without one
+  clobbering another**: real-mode static host (credential-map-file), ephemeral
+  Docker (dynamically-generated driver state), ephemeral EC2/named-keypair
+  (standard TK `transport:` block, resolved via `instance.transport`). See
+  `.github/instructions/bug-fix-workflow.instructions.md` for the exact
+  resolution priority order and why the ordering matters (TK's SSH transport
+  defaults `username` to `"root"`, which is always truthy).
+- **The provisioner and verifier duplicate this resolution logic** rather than
+  sharing it via inheritance (`ChefInfraAgentless` vs. `InspecAgentless`) — a
+  fix in one is easily forgotten in the other. Always check both when fixing
+  credential/endpoint bugs.
+- **`KITCHEN_YAML` env var** changes which config file `kitchen` reads. If a
+  failure references a host/sub-driver that doesn't match the visible
+  `kitchen.yml`, check this env var before assuming a regression.
+- **Stale `.kitchen/*.yml` state files** persist the previous sub-driver's
+  server-id/hostname when a user switches configs without `kitchen destroy`
+  first — causes confusing "wrong host"/"credentials not found" errors that
+  look like code bugs. Compare file mtimes against the active config.
+- **InSpec/Chef license and install-strategy issues** (interactive license
+  prompt, `dpkg` permission errors, `license_acceptance/acceptor` load
+  failures) are almost always source-node environment/install-strategy
+  issues, not KCAI code bugs — but the fix (e.g. `CHEF_LICENSE=accept`,
+  running the installer as root) must be applied consistently to **both**
+  the chef-client and InSpec invocation paths.
 
 ## What NOT to Do
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>Ports the AI-agent dev-process scaffolding from the original <code>chef:agentless-dev</code> branch (skills, instructions, <code>copilot-setup-steps.yml</code>) into this repo, and refreshes it with everything learned across many end-to-end debugging sessions of the agentless epic (CHEF-23408) against real Docker, EC2-ephemeral, and real-mode targets. No functional code changes &mdash; documentation/process files only.</p>

<h2>What's included</h2>
<ul>
<li><code>.github/copilot-setup-steps.yml</code> &mdash; cloud agent setup steps, using this repo's actual <code>bundle exec rake unit</code> / <code>cookstyle</code> commands.</li>
<li><code>.github/instructions/pr-workflow.instructions.md</code> &mdash; branch/PR conventions for the two-repo epic (TKE core + <code>chef/kitchen-agentless</code>), including a note that PRs should not be opened without explicit user approval.</li>
<li><code>.github/instructions/bug-fix-workflow.instructions.md</code> &mdash; rewritten around the actual bug classes hit this epic: the three target-credential provisioning styles and their resolution priority order, provisioner/verifier logic duplication, <code>KITCHEN_YAML</code> and stale <code>.kitchen/*.yml</code> state gotchas, and recurring InSpec/Chef license issues.</li>
<li><code>.github/instructions/agentless-config-extension.instructions.md</code> &mdash; rewritten to reflect the current architecture (agentless logic now lives entirely in <code>chef/kitchen-agentless</code>, not TKE core).</li>
<li><code>.github/skills/create-kitchen-plugin/SKILL.md</code> &mdash; carried over with an added "Provisioner/Verifier Pairing" section.</li>
<li><code>AGENTS.md</code> &mdash; marked both TKE-core stories for CHEF-23408 (CHEF-27348, CHEF-36826) as done, added a "Lessons Learned From KCAI End-to-End Debugging" section.</li>
<li><code>.github/copilot-instructions.md</code> &mdash; added a matching "Lessons Learned: Agentless Mode (CHEF-23408) Cross-Repo Development" section.</li>
</ul>

<p>Repo references were updated from <code>kitchen-chef-infra-agentless</code> to <code>chef/kitchen-agentless</code> to match the plugin's current repo name.</p>

<p>Note: four additional debugging-focused skills (<code>debug-agentless-target-connection</code>, <code>sync-credential-resolution-logic</code>, <code>e2e-target-style-matrix</code>, <code>cleanup-stale-kitchen-state</code>) were drafted but relocated to the <code>chef/kitchen-agentless</code> repo instead, since they reference that repo's own files/classes directly and TKE core should stay agentless-unaware.</p>

<h2>Testing</h2>
<p>Documentation/process files only &mdash; no code changes, no tests required.</p>